### PR TITLE
New: Add support for duplicate object literal properties

### DIFF
--- a/lib/features.js
+++ b/lib/features.js
@@ -66,6 +66,9 @@ module.exports = {
     // enable parsing of shorthand object literal properties
     objectLiteralShorthandProperties: false,
 
+    // Allow duplicate object literal properties (except '__proto__')
+    objectLiteralDuplicateProperties: false,
+
     // enable parsing of generators/yield
     generators: false,
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -68,6 +68,7 @@ module.exports = {
     StrictOctalLiteral: "Octal literals are not allowed in strict mode.",
     StrictDelete: "Delete of an unqualified identifier in strict mode.",
     StrictDuplicateProperty: "Duplicate data property in object literal not allowed in strict mode",
+    DuplicatePrototypeProperty: "Duplicate '__proto__' property in object literal are not allowed",
     AccessorDataProperty: "Object literal may not have data and accessor property with the same name",
     AccessorGetSet: "Object literal may not have multiple get/set accessors with the same name",
     StrictLHSAssignment: "Assignment to eval or arguments is not allowed in strict mode",

--- a/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.config.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    objectLiteralDuplicateProperties: true,
+    objectLiteralComputedProperties: true
+};

--- a/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.result.js
@@ -1,0 +1,450 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "Literal",
+                "value": "use strict",
+                "raw": "\"use strict\"",
+                "range": [
+                    0,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                }
+            },
+            "range": [
+                0,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "proto",
+                        "range": [
+                            19,
+                            24
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 9
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [],
+                        "range": [
+                            27,
+                            29
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 14
+                            }
+                        }
+                    },
+                    "range": [
+                        19,
+                        29
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 3,
+                            "column": 14
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                15,
+                30
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 15
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "x",
+                        "range": [
+                            36,
+                            37
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 5,
+                                "column": 5
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Literal",
+                                    "value": "__proto__",
+                                    "raw": "\"__proto__\"",
+                                    "range": [
+                                        44,
+                                        55
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 13
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "proto",
+                                    "range": [
+                                        58,
+                                        63
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 21
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": true,
+                                "range": [
+                                    43,
+                                    63
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 6,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 21
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Literal",
+                                    "value": "__proto__",
+                                    "raw": "\"__proto__\"",
+                                    "range": [
+                                        67,
+                                        78
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 13
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "proto",
+                                    "range": [
+                                        81,
+                                        86
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 7,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 7,
+                                            "column": 21
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": true,
+                                "range": [
+                                    66,
+                                    86
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 7,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 7,
+                                        "column": 21
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "BinaryExpression",
+                                    "operator": "+",
+                                    "left": {
+                                        "type": "BinaryExpression",
+                                        "operator": "+",
+                                        "left": {
+                                            "type": "Literal",
+                                            "value": "__",
+                                            "raw": "\"__\"",
+                                            "range": [
+                                                90,
+                                                94
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 8,
+                                                    "column": 2
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 6
+                                                }
+                                            }
+                                        },
+                                        "right": {
+                                            "type": "Literal",
+                                            "value": "proto",
+                                            "raw": "\"proto\"",
+                                            "range": [
+                                                97,
+                                                104
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 8,
+                                                    "column": 9
+                                                },
+                                                "end": {
+                                                    "line": 8,
+                                                    "column": 16
+                                                }
+                                            }
+                                        },
+                                        "range": [
+                                            90,
+                                            104
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 8,
+                                                "column": 2
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 16
+                                            }
+                                        }
+                                    },
+                                    "right": {
+                                        "type": "Literal",
+                                        "value": "__",
+                                        "raw": "\"__\"",
+                                        "range": [
+                                            107,
+                                            111
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 8,
+                                                "column": 19
+                                            },
+                                            "end": {
+                                                "line": 8,
+                                                "column": 23
+                                            }
+                                        }
+                                    },
+                                    "range": [
+                                        90,
+                                        111
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 8,
+                                            "column": 2
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 23
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Identifier",
+                                    "name": "proto",
+                                    "range": [
+                                        114,
+                                        119
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 8,
+                                            "column": 26
+                                        },
+                                        "end": {
+                                            "line": 8,
+                                            "column": 31
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": true,
+                                "range": [
+                                    89,
+                                    119
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 8,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 8,
+                                        "column": 31
+                                    }
+                                }
+                            }
+                        ],
+                        "range": [
+                            40,
+                            121
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 5,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 9,
+                                "column": 1
+                            }
+                        }
+                    },
+                    "range": [
+                        36,
+                        121
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 9,
+                            "column": 1
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                32,
+                122
+            ],
+            "loc": {
+                "start": {
+                    "line": 5,
+                    "column": 0
+                },
+                "end": {
+                    "line": 9,
+                    "column": 2
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        122
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 9,
+            "column": 2
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.src.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralDuplicateProperties-and-objectLiteralComputedProperties/proto-computed-property.src.js
@@ -1,0 +1,9 @@
+"use strict";
+
+var proto = {};
+
+var x = {
+	["__proto__"]: proto,
+	["__proto__"]: proto,
+	["__" + "proto" + "__"]: proto
+};

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-property.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 78,
+    "lineNumber": 7,
+    "column": 18,
+    "description": "Duplicate '__proto__' property in object literal are not allowed"
+}

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-property.src.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-property.src.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var proto = {};
+
+var x = {
+	__proto__: proto,
+	__proto__: proto
+};

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-string-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-string-property.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 82,
+    "lineNumber": 7,
+    "column": 20,
+    "description": "Duplicate '__proto__' property in object literal are not allowed"
+}

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-string-property.src.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/proto-string-property.src.js
@@ -1,0 +1,8 @@
+"use strict";
+
+var proto = {};
+
+var x = {
+	"__proto__": proto,
+	"__proto__": proto
+};

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-properties.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-properties.result.js
@@ -1,0 +1,245 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "Literal",
+                "value": "use strict",
+                "raw": "\"use strict\"",
+                "range": [
+                    0,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                }
+            },
+            "range": [
+                0,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "x",
+                        "range": [
+                            19,
+                            20
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 5
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "y",
+                                    "range": [
+                                        26,
+                                        27
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 2
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Literal",
+                                    "value": "first",
+                                    "raw": "'first'",
+                                    "range": [
+                                        29,
+                                        36
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 11
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    26,
+                                    36
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 11
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "y",
+                                    "range": [
+                                        39,
+                                        40
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 2
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Literal",
+                                    "value": "second",
+                                    "raw": "'second'",
+                                    "range": [
+                                        42,
+                                        50
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 12
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    39,
+                                    50
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 12
+                                    }
+                                }
+                            }
+                        ],
+                        "range": [
+                            23,
+                            52
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 1
+                            }
+                        }
+                    },
+                    "range": [
+                        19,
+                        52
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 1
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                15,
+                53
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 2
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        53
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 6,
+            "column": 2
+        }
+    }
+}

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-properties.src.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-properties.src.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var x = {
+	y: 'first',
+	y: 'second'
+};

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-string-properties.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-string-properties.result.js
@@ -1,0 +1,247 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "Literal",
+                "value": "use strict",
+                "raw": "\"use strict\"",
+                "range": [
+                    0,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                }
+            },
+            "range": [
+                0,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "x",
+                        "range": [
+                            19,
+                            20
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 5
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Literal",
+                                    "value": "y",
+                                    "raw": "\"y\"",
+                                    "range": [
+                                        26,
+                                        29
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 4
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Literal",
+                                    "value": "first",
+                                    "raw": "\"first\"",
+                                    "range": [
+                                        31,
+                                        38
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 13
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    26,
+                                    38
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 13
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Literal",
+                                    "value": "y",
+                                    "raw": "\"y\"",
+                                    "range": [
+                                        41,
+                                        44
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 4
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "Literal",
+                                    "value": "second",
+                                    "raw": "\"second\"",
+                                    "range": [
+                                        46,
+                                        54
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 6
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 14
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": false,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    41,
+                                    54
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 14
+                                    }
+                                }
+                            }
+                        ],
+                        "range": [
+                            23,
+                            56
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 6,
+                                "column": 1
+                            }
+                        }
+                    },
+                    "range": [
+                        19,
+                        56
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 6,
+                            "column": 1
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                15,
+                57
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 6,
+                    "column": 2
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        57
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 6,
+            "column": 2
+        }
+    }
+}

--- a/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src.js
+++ b/tests/fixtures/ecma-features/objectLiteralDuplicateProperties/strict-duplicate-string-properties.src.js
@@ -1,0 +1,6 @@
+"use strict";
+
+var x = {
+	"y": "first",
+	"y": "second"
+};


### PR DESCRIPTION
- Adds support for duplicate object properties in ES 6 with the `duplicateObjectLiteralProperties` feature. 
- Continues to forbid duplicate object literals in strict mode otherwise
- Special rules for the `__proto__` property

This feature doesn't exist in esprima-fb yet, so we couldn't use it to help generate tests. Instead all tests were created by this branch and then verified by me. It looks good to me, but a few more pairs of eyes couldn't hurt.