### PR TITLE
New: Add support for default parameters (refs #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ var ast = espree.parse(code, {
         // enable parsing unicode code point escape sequences
         unicodeCodePointEscapes: true,
 
+        // enable parsing of default parameters
+        defaultParams: false,
+
         // enable parsing of for-of statement
         forOf: true,
 

--- a/lib/features.js
+++ b/lib/features.js
@@ -57,6 +57,9 @@ module.exports = {
     // enable parsing unicode code point escape sequences
     unicodeCodePointEscapes: true,
 
+    // enable parsing of default parameters
+    defaultParams: false,
+
     // enable parsing of for-of statements
     forOf: false,
 

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.config.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	objectLiteralShorthandMethods: true,
+	defaultParams: true
+};

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
@@ -1,0 +1,543 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "expression": {
+                "type": "Literal",
+                "value": "use strict",
+                "raw": "\"use strict\"",
+                "range": [
+                    0,
+                    12
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                }
+            },
+            "range": [
+                0,
+                13
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "id": {
+                        "type": "Identifier",
+                        "name": "x",
+                        "range": [
+                            19,
+                            20
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 5
+                            }
+                        }
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "properties": [
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "baz",
+                                    "range": [
+                                        26,
+                                        29
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 4
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "FunctionExpression",
+                                    "id": null,
+                                    "params": [
+                                        {
+                                            "type": "Identifier",
+                                            "name": "a",
+                                            "range": [
+                                                30,
+                                                31
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "column": 5
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "column": 6
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "defaults": [
+                                        {
+                                            "type": "Literal",
+                                            "value": 10,
+                                            "raw": "10",
+                                            "range": [
+                                                34,
+                                                36
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 4,
+                                                    "column": 9
+                                                },
+                                                "end": {
+                                                    "line": 4,
+                                                    "column": 11
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [],
+                                        "range": [
+                                            38,
+                                            40
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 4,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 4,
+                                                "column": 15
+                                            }
+                                        }
+                                    },
+                                    "rest": null,
+                                    "generator": false,
+                                    "expression": false,
+                                    "range": [
+                                        38,
+                                        40
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 4,
+                                            "column": 13
+                                        },
+                                        "end": {
+                                            "line": 4,
+                                            "column": 15
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": true,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    26,
+                                    40
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 4,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 4,
+                                        "column": 15
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "foo",
+                                    "range": [
+                                        43,
+                                        46
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 4
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "FunctionExpression",
+                                    "id": null,
+                                    "params": [
+                                        {
+                                            "type": "Identifier",
+                                            "name": "a",
+                                            "range": [
+                                                47,
+                                                48
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "column": 5
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "column": 6
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Identifier",
+                                            "name": "b",
+                                            "range": [
+                                                50,
+                                                51
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "column": 9
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "defaults": [
+                                        null,
+                                        {
+                                            "type": "Literal",
+                                            "value": 10,
+                                            "raw": "10",
+                                            "range": [
+                                                54,
+                                                56
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 5,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 5,
+                                                    "column": 14
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [],
+                                        "range": [
+                                            58,
+                                            60
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 5,
+                                                "column": 16
+                                            },
+                                            "end": {
+                                                "line": 5,
+                                                "column": 18
+                                            }
+                                        }
+                                    },
+                                    "rest": null,
+                                    "generator": false,
+                                    "expression": false,
+                                    "range": [
+                                        58,
+                                        60
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 5,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 5,
+                                            "column": 18
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": true,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    43,
+                                    60
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 5,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 5,
+                                        "column": 18
+                                    }
+                                }
+                            },
+                            {
+                                "type": "Property",
+                                "key": {
+                                    "type": "Identifier",
+                                    "name": "toast",
+                                    "range": [
+                                        63,
+                                        68
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 1
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 6
+                                        }
+                                    }
+                                },
+                                "value": {
+                                    "type": "FunctionExpression",
+                                    "id": null,
+                                    "params": [
+                                        {
+                                            "type": "Identifier",
+                                            "name": "a",
+                                            "range": [
+                                                69,
+                                                70
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 7
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 8
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Identifier",
+                                            "name": "b",
+                                            "range": [
+                                                72,
+                                                73
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 10
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 11
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "Identifier",
+                                            "name": "c",
+                                            "range": [
+                                                80,
+                                                81
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 19
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "defaults": [
+                                        null,
+                                        {
+                                            "type": "Literal",
+                                            "value": 10,
+                                            "raw": "10",
+                                            "range": [
+                                                76,
+                                                78
+                                            ],
+                                            "loc": {
+                                                "start": {
+                                                    "line": 6,
+                                                    "column": 14
+                                                },
+                                                "end": {
+                                                    "line": 6,
+                                                    "column": 16
+                                                }
+                                            }
+                                        },
+                                        null
+                                    ],
+                                    "body": {
+                                        "type": "BlockStatement",
+                                        "body": [],
+                                        "range": [
+                                            83,
+                                            85
+                                        ],
+                                        "loc": {
+                                            "start": {
+                                                "line": 6,
+                                                "column": 21
+                                            },
+                                            "end": {
+                                                "line": 6,
+                                                "column": 23
+                                            }
+                                        }
+                                    },
+                                    "rest": null,
+                                    "generator": false,
+                                    "expression": false,
+                                    "range": [
+                                        83,
+                                        85
+                                    ],
+                                    "loc": {
+                                        "start": {
+                                            "line": 6,
+                                            "column": 21
+                                        },
+                                        "end": {
+                                            "line": 6,
+                                            "column": 23
+                                        }
+                                    }
+                                },
+                                "kind": "init",
+                                "method": true,
+                                "shorthand": false,
+                                "computed": false,
+                                "range": [
+                                    63,
+                                    85
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 6,
+                                        "column": 1
+                                    },
+                                    "end": {
+                                        "line": 6,
+                                        "column": 23
+                                    }
+                                }
+                            }
+                        ],
+                        "range": [
+                            23,
+                            87
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 3,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 7,
+                                "column": 1
+                            }
+                        }
+                    },
+                    "range": [
+                        19,
+                        87
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 3,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 7,
+                            "column": 1
+                        }
+                    }
+                }
+            ],
+            "kind": "var",
+            "range": [
+                15,
+                88
+            ],
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 7,
+                    "column": 2
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        88
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 7,
+            "column": 2
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.src.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.src.js
@@ -1,0 +1,7 @@
+"use strict";
+
+var x = {
+	baz(a = 10) {},
+	foo(a, b = 10) {},
+	toast(a, b = 10, c) {}
+};

--- a/tests/fixtures/ecma-features/defaultParams/declaration.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/declaration.result.js
@@ -1,0 +1,67 @@
+module.exports = {
+	"type": "Program",
+	"body": [
+		{
+			"type": "FunctionDeclaration",
+			"id": {
+				"type": "Identifier",
+					"name": "f",
+					"range": [9, 10],
+					"loc": {
+					"start": { "line": 1, "column": 9 },
+					"end": { "line": 1, "column": 10 }
+				}
+			},
+				"params": [{
+					"type": "Identifier",
+					"name": "a",
+					"range": [11, 12],
+					"loc": {
+						"start": { "line": 1, "column": 11 },
+						"end": { "line": 1, "column": 12 }
+					}
+				}],
+					"defaults": [{
+				"type": "Literal",
+				"value": 1,
+				"raw": "1",
+				"range": [15, 16],
+				"loc": {
+					"start": { "line": 1, "column": 15 },
+					"end": { "line": 1, "column": 16 }
+				}
+			}],
+				"body": {
+				"type": "BlockStatement",
+					"body": [],
+					"range": [18, 20],
+					"loc": {
+					"start": { "line": 1, "column": 18 },
+					"end": { "line": 1, "column": 20 }
+				}
+			},
+			"rest": null,
+			"generator": false,
+			"expression": false,
+			"range": [0, 20],
+			"loc": {
+				"start": { "line": 1, "column": 0},
+				"end": { "line": 1, "column": 20}
+			}
+		}
+	],
+  	"loc": {
+	    "end": {
+		      "column": 20,
+		      "line": 1
+		},
+	    "start": {
+		      "column": 0,
+		      "line": 1
+		    }
+	  },
+  	"range": [
+	    0,
+	    20
+  	]
+};

--- a/tests/fixtures/ecma-features/defaultParams/declaration.src.js
+++ b/tests/fixtures/ecma-features/defaultParams/declaration.src.js
@@ -1,0 +1,1 @@
+function f(a = 1) {}

--- a/tests/fixtures/ecma-features/defaultParams/expression.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/expression.result.js
@@ -1,0 +1,85 @@
+module.exports = {
+	"type": "Program",
+	"loc": {
+		"end": {
+		  "column": 22,
+		  "line": 1
+		},
+		"start": {
+		  "column": 0,
+		  "line": 1
+		}
+	},
+	"range": [
+		0,
+		22
+	],
+	"body": [
+		{
+			"type": "ExpressionStatement",
+			"expression": {
+				"type": "AssignmentExpression",
+					"operator": "=",
+					"left": {
+					"type": "Identifier",
+						"name": "x",
+						"range": [0, 1],
+						"loc": {
+						"start": { "line": 1, "column": 0 },
+						"end": { "line": 1, "column": 1 }
+					}
+				},
+				"right": {
+					"type": "FunctionExpression",
+						"id": null,
+						"params": [{
+						"type": "Identifier",
+						"name": "y",
+						"range": [13, 14],
+						"loc": {
+							"start": { "line": 1, "column": 13 },
+							"end": { "line": 1, "column": 14 }
+						}
+					}],
+						"defaults": [{
+						"type": "Literal",
+						"value": 1,
+						"raw": "1",
+						"range": [17, 18],
+						"loc": {
+							"start": { "line": 1, "column": 17 },
+							"end": { "line": 1, "column": 18 }
+						}
+					}],
+						"body": {
+						"type": "BlockStatement",
+							"body": [],
+							"range": [20, 22],
+							"loc": {
+							"start": { "line": 1, "column": 20 },
+							"end": { "line": 1, "column": 22 }
+						}
+					},
+					"rest": null,
+						"generator": false,
+						"expression": false,
+						"range": [4, 22],
+						"loc": {
+						"start": { "line": 1, "column": 4 },
+						"end": { "line": 1, "column": 22 }
+					}
+				},
+				"range": [0, 22],
+					"loc": {
+					"start": { "line": 1, "column": 0 },
+					"end": { "line": 1, "column": 22 }
+				}
+			},
+			"range": [0, 22],
+			"loc": {
+				"start": { "line": 1, "column": 0},
+				"end": { "line": 1, "column": 22}
+			}
+		}
+	]
+};

--- a/tests/fixtures/ecma-features/defaultParams/expression.src.js
+++ b/tests/fixtures/ecma-features/defaultParams/expression.src.js
@@ -1,0 +1,1 @@
+x = function(y = 1) {}

--- a/tests/fixtures/ecma-features/defaultParams/method.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/method.result.js
@@ -1,0 +1,114 @@
+module.exports = {
+	"type": "Program",
+	"body": [
+		{
+			"type": "ExpressionStatement",
+			"expression": {
+				"type": "AssignmentExpression",
+				"operator": "=",
+				"left": {
+					"type": "Identifier",
+					"name": "x",
+					"range": [0, 1],
+					"loc": {
+						"start": { "line": 1, "column": 0},
+						"end": { "line": 1, "column": 1}
+					}
+				},
+				"right": {
+					"type": "ObjectExpression",
+					"properties": [{
+						"type": "Property",
+						"computed": false,
+						"key": {
+							"type": "Identifier",
+							"name": "f",
+							"range": [6, 7],
+							"loc": {
+								"start": { "line": 1, "column": 6},
+								"end": { "line": 1, "column": 7}
+							}
+						},
+						"value": {
+							"type": "FunctionExpression",
+							"id": null,
+							"params": [{
+								"type": "Identifier",
+								"name": "a",
+								"range": [18, 19],
+								"loc": {
+									"start": { "line": 1, "column": 18},
+									"end": { "line": 1, "column": 19}
+								}
+							}],
+							"defaults": [{
+								"type": "Literal",
+								"value": 1,
+								"raw": "1",
+								"range": [20, 21],
+								"loc": {
+									"start": { "line": 1, "column": 20},
+									"end": { "line": 1, "column": 21}
+								}
+							}],
+							"body": {
+								"type": "BlockStatement",
+								"body": [],
+								"range": [23, 25],
+								"loc": {
+									"start": { "line": 1, "column": 23},
+									"end": { "line": 1, "column": 25}
+								}
+							},
+							"rest": null,
+							"generator": false,
+							"expression": false,
+							"range": [9, 25],
+							"loc": {
+								"start": { "line": 1, "column": 9},
+								"end": { "line": 1, "column": 25}
+							}
+						},
+						"kind": "init",
+						"method": false,
+						"shorthand": false,
+						"range": [6, 25],
+						"loc": {
+							"start": { "line": 1, "column": 6},
+							"end": { "line": 1, "column": 25}
+						}
+					}],
+					"range": [4, 27],
+					"loc": {
+						"start": { "line": 1, "column": 4},
+						"end": { "line": 1, "column": 27}
+					}
+				},
+				"range": [0, 27],
+				"loc": {
+					"start": { "line": 1, "column": 0},
+					"end": { "line": 1, "column": 27}
+				}
+			},
+			"range": [0, 27],
+			"loc": {
+				"start": { "line": 1, "column": 0},
+				"end": { "line": 1, "column": 27}
+			}
+		}
+	],
+	"loc": {
+		"end": {
+	  		"column": 27,
+		  	"line": 1
+		},
+		"start": {
+	  		"column": 0,
+	  		"line": 1
+		}
+	},
+	"range": [
+		0,
+		27
+	]
+};

--- a/tests/fixtures/ecma-features/defaultParams/method.src.js
+++ b/tests/fixtures/ecma-features/defaultParams/method.src.js
@@ -1,0 +1,1 @@
+x = { f: function(a=1) {} }

--- a/tests/fixtures/ecma-features/defaultParams/not-all-params.result.js
+++ b/tests/fixtures/ecma-features/defaultParams/not-all-params.result.js
@@ -1,0 +1,192 @@
+module.exports = {
+	"range": [
+		0,
+		36
+	],
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 1,
+			"column": 36
+		}
+	},
+	"type": "Program",
+	"body": [
+		{
+			"range": [
+				0,
+				36
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 36
+				}
+			},
+			"type": "VariableDeclaration",
+			"declarations": [
+				{
+					"range": [
+						4,
+						35
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 4
+						},
+						"end": {
+							"line": 1,
+							"column": 35
+						}
+					},
+					"type": "VariableDeclarator",
+					"id": {
+						"range": [
+							4,
+							7
+						],
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 4
+							},
+							"end": {
+								"line": 1,
+								"column": 7
+							}
+						},
+						"type": "Identifier",
+						"name": "foo"
+					},
+					"init": {
+						"range": [
+							10,
+							35
+						],
+						"loc": {
+							"start": {
+								"line": 1,
+								"column": 10
+							},
+							"end": {
+								"line": 1,
+								"column": 35
+							}
+						},
+						"type": "FunctionExpression",
+						"id": null,
+						"params": [
+							{
+								"range": [
+									19,
+									20
+								],
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 19
+									},
+									"end": {
+										"line": 1,
+										"column": 20
+									}
+								},
+								"type": "Identifier",
+								"name": "a"
+							},
+							{
+								"range": [
+									22,
+									23
+								],
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 22
+									},
+									"end": {
+										"line": 1,
+										"column": 23
+									}
+								},
+								"type": "Identifier",
+								"name": "b"
+							},
+							{
+								"range": [
+									30,
+									31
+								],
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 30
+									},
+									"end": {
+										"line": 1,
+										"column": 31
+									}
+								},
+								"type": "Identifier",
+								"name": "c"
+							}
+						],
+						"defaults": [
+							null,
+							{
+								"range": [
+									26,
+									28
+								],
+								"loc": {
+									"start": {
+										"line": 1,
+										"column": 26
+									},
+									"end": {
+										"line": 1,
+										"column": 28
+									}
+								},
+								"type": "Literal",
+								"value": 42,
+								"raw": "42"
+							},
+							null
+						],
+						"body": {
+							"range": [
+								33,
+								35
+							],
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 33
+								},
+								"end": {
+									"line": 1,
+									"column": 35
+								}
+							},
+							"type": "BlockStatement",
+							"body": []
+						},
+						"rest": null,
+						"generator": false,
+						"expression": false
+					}
+				}
+			],
+			"kind": "var"
+		}
+	]
+};

--- a/tests/fixtures/ecma-features/defaultParams/not-all-params.src.js
+++ b/tests/fixtures/ecma-features/defaultParams/not-all-params.src.js
@@ -1,0 +1,1 @@
+var foo = function(a, b = 42, c) {};


### PR DESCRIPTION
Basically a simple port of ariya/esprima@0384add.

Destructuring isn't a feature yet, so we're not testing that inside of default params, though it's pretty important as well. Let me know if I missed anything.