### PR TITLE
When ecmaFeatures.forOf is true, check for operator is "undefined" when match keyword is "in" #39

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -3473,7 +3473,7 @@ function parseForStatement(opts) {
                     throwErrorTolerant({}, Messages.InvalidLHSInForIn);
                 }
 
-                lex();
+                operator = lex();
                 left = init;
                 right = parseExpression();
                 init = null;

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.config.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    forOf: true
+};

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.result.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.result.js
@@ -1,0 +1,57 @@
+module.exports = {
+    "type" : "Program",
+    "body" : [{
+        "type" : "ForInStatement",
+        "left" : {
+            "type"        : "VariableDeclaration",
+            "declarations": [{
+                "type" : "VariableDeclarator",
+                "id"   : {
+                    "type" : "Identifier",
+                    "name" : "k",
+                    "range": [17, 18],
+                    "loc"  : {"start": {"line": 2, "column": 9}, "end": {"line": 2, "column": 10}}
+                },
+                "init" : null,
+                "range": [17, 18],
+                "loc"  : {"start": {"line": 2, "column": 9}, "end": {"line": 2, "column": 10}}
+            }],
+            "kind"        : "var",
+            "range"       : [13, 18],
+            "loc"         : {"start": {"line": 2, "column": 5}, "end": {"line": 2, "column": 10}}
+        },
+        "right": {
+            "type" : "Identifier",
+            "name" : "console",
+            "range": [22, 29],
+            "loc"  : {"start": {"line": 2, "column": 14}, "end": {"line": 2, "column": 21}}
+        },
+        "body" : {
+            "type" : "BlockStatement",
+            "body" : [{
+                "type"      : "ExpressionStatement",
+                "expression": {
+                    "type"     : "CallExpression",
+                    "callee"   : {
+                        "type" : "Identifier",
+                        "name" : "doSomething",
+                        "range": [37, 48],
+                        "loc"  : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 15}}
+                    },
+                    "arguments": [],
+                    "range"    : [37, 50],
+                    "loc"      : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 17}}
+                },
+                "range"     : [37, 51],
+                "loc"       : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 18}}
+            }],
+            "range": [31, 53],
+            "loc"  : {"start": {"line": 2, "column": 23}, "end": {"line": 4, "column": 1}}
+        },
+        "each" : false,
+        "range": [8, 53],
+        "loc"  : {"start": {"line": 2, "column": 0}, "end": {"line": 4, "column": 1}}
+    }],
+    "range": [8, 53],
+    "loc"  : {"start": {"line": 2, "column": 0}, "end": {"line": 4, "column": 1}}
+};

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.src.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring-inline.src.js
@@ -1,0 +1,4 @@
+//var k
+for (var k in console) {
+    doSomething();
+}

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.config.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    forOf: true
+};

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.result.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.result.js
@@ -1,0 +1,62 @@
+module.exports = {
+    "type" : "Program",
+    "body" : [{
+        "type"        : "VariableDeclaration",
+        "declarations": [{
+            "type" : "VariableDeclarator",
+            "id"   : {
+                "type" : "Identifier",
+                "name" : "k",
+                "range": [4, 5],
+                "loc"  : {"start": {"line": 1, "column": 4}, "end": {"line": 1, "column": 5}}
+            },
+            "init" : null,
+            "range": [4, 5],
+            "loc"  : {"start": {"line": 1, "column": 4}, "end": {"line": 1, "column": 5}}
+        }],
+        "kind"        : "var",
+        "range"       : [0, 6],
+        "loc"         : {"start": {"line": 1, "column": 0}, "end": {"line": 1, "column": 6}}
+    }, {
+        "type" : "ForInStatement",
+        "left" : {
+            "type" : "Identifier",
+            "name" : "k",
+            "range": [12, 13],
+            "loc"  : {"start": {"line": 2, "column": 5}, "end": {"line": 2, "column": 6}}
+        },
+        "right": {
+            "type" : "Identifier",
+            "name" : "console",
+            "range": [17, 24],
+            "loc"  : {"start": {"line": 2, "column": 10}, "end": {"line": 2, "column": 17}}
+        },
+        "body" : {
+            "type" : "BlockStatement",
+            "body" : [{
+                "type"      : "ExpressionStatement",
+                "expression": {
+                    "type"     : "CallExpression",
+                    "callee"   : {
+                        "type" : "Identifier",
+                        "name" : "doSomething",
+                        "range": [32, 43],
+                        "loc"  : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 15}}
+                    },
+                    "arguments": [],
+                    "range"    : [32, 45],
+                    "loc"      : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 17}}
+                },
+                "range"     : [32, 46],
+                "loc"       : {"start": {"line": 3, "column": 4}, "end": {"line": 3, "column": 18}}
+            }],
+            "range": [26, 48],
+            "loc"  : {"start": {"line": 2, "column": 19}, "end": {"line": 4, "column": 1}}
+        },
+        "each" : false,
+        "range": [7, 48],
+        "loc"  : {"start": {"line": 2, "column": 0}, "end": {"line": 4, "column": 1}}
+    }],
+    "range": [0, 48],
+    "loc"  : {"start": {"line": 1, "column": 0}, "end": {"line": 4, "column": 1}}
+};

--- a/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.src.js
+++ b/tests/fixtures/ecma-features-mix/forOf-operator/for-of-declaring.src.js
@@ -1,0 +1,4 @@
+var k;
+for (k in console) {
+    doSomething();
+}


### PR DESCRIPTION
Enable forOf
```
{ forOf: true }
```

Espree will error with "undefined" 
```
for (var k in console) {
    doSomething();
}
```

See test files in PR for examples.