### PR TITLE
Fix: Tokenization for template strings (fixes #44)

### DIFF
--- a/tests/fixtures/tokenize/template-string-embedded-result.tokens.js
+++ b/tests/fixtures/tokenize/template-string-embedded-result.tokens.js
@@ -1,0 +1,129 @@
+// var foo = `hi${bar}`;
+module.exports = [
+    {
+        "type": "Keyword",
+        "value": "var",
+        "range": [
+            0,
+            3
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 1,
+                "column": 3
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "foo",
+        "range": [
+            4,
+            7
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 4
+            },
+            "end": {
+                "line": 1,
+                "column": 7
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": "=",
+        "range": [
+            8,
+            9
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 8
+            },
+            "end": {
+                "line": 1,
+                "column": 9
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "`hi${",
+        "range": [
+            10,
+            15
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 10
+            },
+            "end": {
+                "line": 1,
+                "column": 15
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "bar",
+        "range": [
+            15,
+            18
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 15
+            },
+            "end": {
+                "line": 1,
+                "column": 18
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "}`",
+        "range": [
+            18,
+            20
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 18
+            },
+            "end": {
+                "line": 1,
+                "column": 20
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [
+            20,
+            21
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 20
+            },
+            "end": {
+                "line": 1,
+                "column": 21
+            }
+        }
+    }
+];

--- a/tests/fixtures/tokenize/template-string-expressions-result.tokens.js
+++ b/tests/fixtures/tokenize/template-string-expressions-result.tokens.js
@@ -1,0 +1,201 @@
+// var foo = `Hello ${b}. a + 5 = ${a + 5}`;
+module.exports = [
+    {
+        "type": "Keyword",
+        "value": "var",
+        "range": [
+            0,
+            3
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 1,
+                "column": 3
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "foo",
+        "range": [
+            4,
+            7
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 4
+            },
+            "end": {
+                "line": 1,
+                "column": 7
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": "=",
+        "range": [
+            8,
+            9
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 8
+            },
+            "end": {
+                "line": 1,
+                "column": 9
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "`Hello ${",
+        "range": [
+            10,
+            19
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 10
+            },
+            "end": {
+                "line": 1,
+                "column": 19
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "b",
+        "range": [
+            19,
+            20
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 19
+            },
+            "end": {
+                "line": 1,
+                "column": 20
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "}. a + 5 = ${",
+        "range": [
+            20,
+            33
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 20
+            },
+            "end": {
+                "line": 1,
+                "column": 33
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "a",
+        "range": [
+            33,
+            34
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 33
+            },
+            "end": {
+                "line": 1,
+                "column": 34
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": "+",
+        "range": [
+            35,
+            36
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 35
+            },
+            "end": {
+                "line": 1,
+                "column": 36
+            }
+        }
+    },
+    {
+        "type": "Numeric",
+        "value": "5",
+        "range": [
+            37,
+            38
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 37
+            },
+            "end": {
+                "line": 1,
+                "column": 38
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "}`",
+        "range": [
+            38,
+            40
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 38
+            },
+            "end": {
+                "line": 1,
+                "column": 40
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [
+            40,
+            41
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 40
+            },
+            "end": {
+                "line": 1,
+                "column": 41
+            }
+        }
+    }
+];

--- a/tests/fixtures/tokenize/template-string-simple-result.tokens.js
+++ b/tests/fixtures/tokenize/template-string-simple-result.tokens.js
@@ -1,0 +1,93 @@
+// var foo = `hi`;
+module.exports = [
+    {
+        "type": "Keyword",
+        "value": "var",
+        "range": [
+            0,
+            3
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 1,
+                "column": 3
+            }
+        }
+    },
+    {
+        "type": "Identifier",
+        "value": "foo",
+        "range": [
+            4,
+            7
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 4
+            },
+            "end": {
+                "line": 1,
+                "column": 7
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": "=",
+        "range": [
+            8,
+            9
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 8
+            },
+            "end": {
+                "line": 1,
+                "column": 9
+            }
+        }
+    },
+    {
+        "type": "Template",
+        "value": "`hi`",
+        "range": [
+            10,
+            14
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 10
+            },
+            "end": {
+                "line": 1,
+                "column": 14
+            }
+        }
+    },
+    {
+        "type": "Punctuator",
+        "value": ";",
+        "range": [
+            14,
+            15
+        ],
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 14
+            },
+            "end": {
+                "line": 1,
+                "column": 15
+            }
+        }
+    }
+];

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -95,6 +95,40 @@ describe("tokenize()", function() {
         assert.deepEqual(tokens, require("../fixtures/tokenize/regexp-y-result.tokens.js"));
     });
 
+
+    describe("templateStrings", function() {
+        it("should produce tokens when tokenizing simple template string", function() {
+            var tokens = espree.tokenize("var foo = `hi`;", {
+                ecmaFeatures: { templateStrings: true },
+                loc: true,
+                range: true
+            });
+            assert.deepEqual(tokens, require("../fixtures/tokenize/template-string-simple-result.tokens.js"));
+        });
+
+        it("should produce tokens when tokenizing template string with embedded variable", function() {
+            var tokens = espree.tokenize("var foo = `hi${bar}`;", {
+                ecmaFeatures: { templateStrings: true },
+                loc: true,
+                range: true
+            });
+            assert.deepEqual(tokens, require("../fixtures/tokenize/template-string-embedded-result.tokens.js"));
+        });
+
+        it("should produce tokens when tokenizing template string with embedded expressions", function() {
+            var tokens = espree.tokenize("var foo = `Hello ${b}. a + 5 = ${a + 5}`;", {
+                ecmaFeatures: { templateStrings: true },
+                loc: true,
+                range: true
+            });
+            assert.deepEqual(tokens, require("../fixtures/tokenize/template-string-expressions-result.tokens.js"));
+        });
+
+
+    });
+
+
+
     // Make sure we don't introduce the same regex parsing error as Esprima
     it("should produce tokens when using regular expression wrapped in parens", function() {
         var tokens = espree.tokenize("(/foo/).test(bar);", {


### PR DESCRIPTION
Template strings really mess with tokenization because the tokens actually are different depending on the context before a `}` is encountered. Yuck. But the nice thing now is that this code:

```
`Hi ${foo} you.`;
```

Will produce:

1. `` "`Hi ${" `` (Template)
2. `"foo"` (identifier)
3. `` "} you.`" `` (Template)