### PR TITLE
Fix: create-test tool not complaining properly

### DIFF
--- a/tools/create-test.js
+++ b/tools/create-test.js
@@ -69,7 +69,7 @@ var rawCode = shelljs.cat(codeFilename),
 // pop off first code, it will be an empty string
 code.shift();
 
-if (sections.length !== code.length) {
+if (!sections || sections.length !== code.length) {
     console.error("Missing a /*!espree-section: name*/ in the code file.");
     process.exit(1);
 }


### PR DESCRIPTION
When you mess up the pattern it wasn't showing the correct error. It used to show:

```
/Users/jamuferguson/dev/espree/tools/create-test.js:72
if (sections.length !== code.length) {
            ^
TypeError: Cannot read property 'length' of null
    at Object.<anonymous> (/Users/jamuferguson/dev/espree/tools/create-test.js:72:13)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3

```