### PR TITLE
Fix: Extend property method range and loc to include params (fixes #36)

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -2375,8 +2375,7 @@ function parsePropertyFunction(options) {
         previousYieldAllowed = state.yieldAllowed,
         params = options.params || [],
         defaults = options.defaults || [],
-        body,
-        marker = markerCreate();
+        body;
 
     state.yieldAllowed = options.generator;
 
@@ -2393,7 +2392,7 @@ function parsePropertyFunction(options) {
     strict = previousStrict;
     state.yieldAllowed = previousYieldAllowed;
 
-    return markerApply(marker, astNodeFactory.createFunctionExpression(
+    return markerApply(options.marker, astNodeFactory.createFunctionExpression(
         null,
         params,
         defaults,
@@ -2406,6 +2405,7 @@ function parsePropertyFunction(options) {
 
 function parsePropertyMethodFunction(options) {
     var previousStrict = strict,
+        marker = markerCreate(),
         tmp,
         method;
 
@@ -2421,7 +2421,8 @@ function parsePropertyMethodFunction(options) {
         params: tmp.params,
         defaults: tmp.defaults,
         rest: tmp.rest,
-        generator: options ? options.generator : false
+        generator: options ? options.generator : false,
+        marker: marker
     });
 
     strict = previousStrict;
@@ -2461,7 +2462,7 @@ function parseObjectPropertyKey() {
 }
 
 function parseObjectProperty() {
-    var token, key, id, param, computed;
+    var token, key, id, param, computed, methodMarker;
     var allowComputed = extra.ecmaFeatures.objectLiteralComputedProperties,
         allowMethod = extra.ecmaFeatures.objectLiteralShorthandMethods,
         allowShorthand = extra.ecmaFeatures.objectLiteralShorthandProperties,
@@ -2483,6 +2484,7 @@ function parseObjectProperty() {
         if (token.value === "get" && !(match(":") || match("("))) {
             computed = (lookahead.value === "[");
             key = parseObjectPropertyKey();
+            methodMarker = markerCreate();
             expect("(");
             expect(")");
             return markerApply(
@@ -2490,7 +2492,10 @@ function parseObjectProperty() {
                 astNodeFactory.createProperty(
                     "get",
                     key,
-                    parsePropertyFunction({ generator: false }),
+                    parsePropertyFunction({
+                        generator: false,
+                        marker: methodMarker
+                    }),
                     false,
                     false,
                     computed
@@ -2501,6 +2506,7 @@ function parseObjectProperty() {
         if (token.value === "set" && !(match(":") || match("("))) {
             computed = (lookahead.value === "[");
             key = parseObjectPropertyKey();
+            methodMarker = markerCreate();
             expect("(");
             token = lookahead;
             param = [ parseVariableIdentifier() ];
@@ -2513,7 +2519,8 @@ function parseObjectProperty() {
                     parsePropertyFunction({
                         params: param,
                         generator: false,
-                        name: token
+                        name: token,
+                        marker: methodMarker
                     }),
                     false,
                     false,

--- a/tests/fixtures/ast/Object-Initializer.json
+++ b/tests/fixtures/ast/Object-Initializer.json
@@ -1219,13 +1219,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                15,
                                 36
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -1371,13 +1371,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                15,
                                 20
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -1523,13 +1523,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                15,
+                                12,
                                 17
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 15
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
@@ -1675,13 +1675,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                17,
+                                14,
                                 19
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 17
+                                    "column": 14
                                 },
                                 "end": {
                                     "line": 1,
@@ -1827,13 +1827,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                15,
                                 20
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -1979,13 +1979,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                17,
+                                14,
                                 19
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 17
+                                    "column": 14
                                 },
                                 "end": {
                                     "line": 1,
@@ -2132,13 +2132,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                20,
+                                17,
                                 22
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 20
+                                    "column": 17
                                 },
                                 "end": {
                                     "line": 1,
@@ -2285,13 +2285,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                15,
+                                12,
                                 17
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 15
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
@@ -2528,13 +2528,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                19,
+                                15,
                                 34
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 19
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -2771,13 +2771,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                16,
+                                12,
                                 28
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 16
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
@@ -3014,13 +3014,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                14,
                                 32
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 14
                                 },
                                 "end": {
                                     "line": 1,
@@ -3257,13 +3257,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                19,
+                                15,
                                 34
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 19
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -3500,13 +3500,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                14,
                                 32
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 14
                                 },
                                 "end": {
                                     "line": 1,
@@ -3744,13 +3744,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                20,
+                                16,
                                 34
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 20
+                                    "column": 16
                                 },
                                 "end": {
                                     "line": 1,
@@ -3988,13 +3988,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                16,
+                                12,
                                 30
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 16
+                                    "column": 12
                                 },
                                 "end": {
                                     "line": 1,
@@ -4697,13 +4697,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                18,
+                                15,
                                 36
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 18
+                                    "column": 15
                                 },
                                 "end": {
                                     "line": 1,
@@ -4868,13 +4868,13 @@
                             "generator": false,
                             "expression": false,
                             "range": [
-                                55,
+                                47,
                                 75
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 55
+                                    "column": 47
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ast/Tolerant-parse.json
+++ b/tests/fixtures/ast/Tolerant-parse.json
@@ -4003,13 +4003,13 @@
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        32,
+                                        25,
                                         34
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 1,
-                                            "column": 32
+                                            "column": 25
                                         },
                                         "end": {
                                             "line": 1,
@@ -4671,13 +4671,13 @@
                                         "generator": false,
                                         "expression": false,
                                         "range": [
-                                            32,
+                                            29,
                                             34
                                         ],
                                         "loc": {
                                             "start": {
                                                 "line": 1,
-                                                "column": 32
+                                                "column": 29
                                             },
                                             "end": {
                                                 "line": 1,
@@ -4751,13 +4751,13 @@
                                         "generator": false,
                                         "expression": false,
                                         "range": [
-                                            44,
+                                            41,
                                             46
                                         ],
                                         "loc": {
                                             "start": {
                                                 "line": 1,
-                                                "column": 44
+                                                "column": 41
                                             },
                                             "end": {
                                                 "line": 1,
@@ -5026,13 +5026,13 @@
                                         "generator": false,
                                         "expression": false,
                                         "range": [
-                                            39,
+                                            36,
                                             41
                                         ],
                                         "loc": {
                                             "start": {
                                                 "line": 1,
-                                                "column": 39
+                                                "column": 36
                                             },
                                             "end": {
                                                 "line": 1,
@@ -5262,13 +5262,13 @@
                                         "generator": false,
                                         "expression": false,
                                         "range": [
-                                            33,
+                                            29,
                                             35
                                         ],
                                         "loc": {
                                             "start": {
                                                 "line": 1,
-                                                "column": 33
+                                                "column": 29
                                             },
                                             "end": {
                                                 "line": 1,

--- a/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-short.result.js
+++ b/tests/fixtures/ecma-features-mix/destructuring-and-defaultParams/param-object-short.result.js
@@ -208,13 +208,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                19,
+                                3,
                                 21
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 19
+                                    "column": 3
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-defaultParams/default-params.result.js
@@ -149,13 +149,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        38,
+                                        29,
                                         40
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 4,
-                                            "column": 13
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 4,
@@ -287,13 +287,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        58,
+                                        46,
                                         60
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 5,
-                                            "column": 16
+                                            "column": 4
                                         },
                                         "end": {
                                             "line": 5,
@@ -444,13 +444,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        83,
+                                        68,
                                         85
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 6,
-                                            "column": 21
+                                            "column": 6
                                         },
                                         "end": {
                                             "line": 6,

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-destructuring/array-destructuring.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-destructuring/array-destructuring.result.js
@@ -109,13 +109,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                14,
+                                4,
                                 16
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 14
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/generator-object-literal-method.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/generator-object-literal-method.result.js
@@ -128,13 +128,13 @@ module.exports = {
                                     "generator": true,
                                     "expression": false,
                                     "range": [
-                                        19,
+                                        16,
                                         31
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 1,
-                                            "column": 19
+                                            "column": 16
                                         },
                                         "end": {
                                             "line": 1,

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-objectLiteralComputedProperties/computed-method-property.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-objectLiteralComputedProperties/computed-method-property.result.js
@@ -110,13 +110,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        22,
+                                        19,
                                         49
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 2,
-                                            "column": 12
+                                            "column": 9
                                         },
                                         "end": {
                                             "line": 4,

--- a/tests/fixtures/ecma-features-mix/restParams-and-destructuring/shortHand-destructuring-array.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-destructuring/shortHand-destructuring-array.result.js
@@ -107,13 +107,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                17,
+                                4,
                                 19
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 17
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ecma-features-mix/restParams-and-destructuring/shortHand-multi-destructuring.result.js
+++ b/tests/fixtures/ecma-features-mix/restParams-and-destructuring/shortHand-multi-destructuring.result.js
@@ -411,13 +411,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                46,
+                                4,
                                 48
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 46
+                                    "column": 4
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ecma-features/objectLiteralComputedProperties/computed-getter-and-setter.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralComputedProperties/computed-getter-and-setter.result.js
@@ -53,13 +53,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                12,
+                                9,
                                 14
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 12
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 1,
@@ -152,13 +152,13 @@ module.exports = {
                             "generator": false,
                             "expression": false,
                             "range": [
-                                27,
+                                23,
                                 29
                             ],
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 27
+                                    "column": 23
                                 },
                                 "end": {
                                     "line": 1,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/method-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/method-property.result.js
@@ -110,13 +110,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        20,
+                                        17,
                                         47
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 2,
-                                            "column": 10
+                                            "column": 7
                                         },
                                         "end": {
                                             "line": 4,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-get.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-get.result.js
@@ -74,13 +74,13 @@ module.exports = {
                                 "generator": false,
                                 "expression": false,
                                 "range": [
-                                    16,
+                                    13,
                                     23
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 10
+                                        "column": 7
                                     },
                                     "end": {
                                         "line": 3,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-set.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-named-set.result.js
@@ -74,13 +74,13 @@ module.exports = {
                                 "generator": false,
                                 "expression": false,
                                 "range": [
-                                    16,
+                                    13,
                                     23
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 10
+                                        "column": 7
                                     },
                                     "end": {
                                         "line": 3,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-argument.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-argument.result.js
@@ -93,13 +93,13 @@ module.exports = {
                                 "generator": false,
                                 "expression": false,
                                 "range": [
-                                    23,
+                                    16,
                                     31
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 17
+                                        "column": 10
                                     },
                                     "end": {
                                         "line": 4,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-string-name.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method-with-string-name.result.js
@@ -75,13 +75,13 @@ module.exports = {
                                 "generator": false,
                                 "expression": false,
                                 "range": [
-                                    21,
+                                    18,
                                     28
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 15
+                                        "column": 12
                                     },
                                     "end": {
                                         "line": 3,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/simple-method.result.js
@@ -74,13 +74,13 @@ module.exports = {
                                 "generator": false,
                                 "expression": false,
                                 "range": [
-                                    19,
+                                    16,
                                     26
                                 ],
                                 "loc": {
                                     "start": {
                                         "line": 2,
-                                        "column": 13
+                                        "column": 10
                                     },
                                     "end": {
                                         "line": 3,

--- a/tests/fixtures/ecma-features/objectLiteralShorthandMethods/string-name-method-property.result.js
+++ b/tests/fixtures/ecma-features/objectLiteralShorthandMethods/string-name-method-property.result.js
@@ -111,13 +111,13 @@ module.exports = {
                                     "generator": false,
                                     "expression": false,
                                     "range": [
-                                        22,
+                                        19,
                                         49
                                     ],
                                     "loc": {
                                         "start": {
                                             "line": 2,
-                                            "column": 12
+                                            "column": 9
                                         },
                                         "end": {
                                             "line": 4,


### PR DESCRIPTION
This is jquery/esprima#1036 ported to Espree.

Previously, the range and loc for get, set, and shorthand methods inside object literal properties included only the method body, meaning a method's parameters were outside the range of their parent `FunctionExpression` node. This was happening because the marker for the `FunctionExpression` node wasn't being created until `parsePropertyFunction` was called, by which point the mothod's parameters had already been parsed. This PR solves the issue by creating the marker for the start of the `FunctionExpression` node as soon as it determines that the property is a get, set, or shorthand method, then passing the marker into `parsePropertyFunction`.

Though #36 only describes the specific case of generator shorthand methods, the same bug is present on get, set, and shorthand property methods, and this PR fixes all three cases.

The only functional change here is in `espree.js` itself; the other files are all updated tests.