### PR TITLE
Test: strict mode enforced in modules (refs #72)

### DIFF
--- a/tests/fixtures/modules/import/error-delete.result.js
+++ b/tests/fixtures/modules/import/error-delete.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"index": 27,
+	"lineNumber": 2,
+	"column": 9,
+	"description": "Delete of an unqualified identifier in strict mode."
+}

--- a/tests/fixtures/modules/import/error-delete.src.js
+++ b/tests/fixtures/modules/import/error-delete.src.js
@@ -1,0 +1,2 @@
+import x from "x";
+delete x;

--- a/tests/fixtures/modules/import/error-strict.result.js
+++ b/tests/fixtures/modules/import/error-strict.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 28,
+    "lineNumber": 3,
+    "column": 1,
+    "description": "Strict mode code may not include a with statement"
+}

--- a/tests/fixtures/modules/import/error-strict.src.js
+++ b/tests/fixtures/modules/import/error-strict.src.js
@@ -1,0 +1,5 @@
+import house from "house";
+
+with (house) {
+	console.log(roof);
+}


### PR DESCRIPTION
Not the most advanced tests, but should effectively ensure we're covered at the basic level. 

I believe the `import` statement is required because the way the `module` tests currently work in that they need to break when the module feature is off.