### PR TITLE
Test: missing tests for modules & classes (refs #72)

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -4842,8 +4842,7 @@ function parseExportDefaultDeclaration() {
           declaration = parseFunctionExpression();
           return markerApply(marker, astNodeFactory.createExportDefaultDeclaration(declaration));
         } else if (lookahead.value === "class") {
-            // TODO: change this to declaration once we get ClassDeclaration with nullable name
-            parseClassExpression();
+            declaration = parseClassDeclaration();
             return markerApply(marker, astNodeFactory.createExportDefaultDeclaration(declaration));
         }
     }
@@ -5106,7 +5105,7 @@ function parseClassExpression() {
 }
 
 function parseClassDeclaration() {
-    var id, superClass = null, marker = markerCreate(),
+    var id = null, superClass = null, marker = markerCreate(),
         previousStrict = strict, classBody;
 
     // classes run in strict mode
@@ -5114,7 +5113,9 @@ function parseClassDeclaration() {
 
     expectKeyword("class");
 
-    id = parseVariableIdentifier();
+    if (lookahead.type === Token.Identifier) {
+        id = parseVariableIdentifier();
+    }
 
     if (matchKeyword("extends")) {
         lex();

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.result.js
@@ -1,0 +1,107 @@
+module.exports = {
+	"type": "Program",
+	"body": [
+		{
+			"type": "ExportDefaultDeclaration",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"id": null,
+				"superClass": {
+					"type": "Identifier",
+					"name": "bar",
+					"range": [
+						29,
+						32
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 29
+						},
+						"end": {
+							"line": 1,
+							"column": 32
+						}
+					}
+				},
+				"body": {
+					"type": "ClassBody",
+					"body": [],
+					"range": [
+						33,
+						35
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 33
+						},
+						"end": {
+							"line": 1,
+							"column": 35
+						}
+					}
+				},
+				"range": [
+					15,
+					35
+				],
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 15
+					},
+					"end": {
+						"line": 1,
+						"column": 35
+					}
+				}
+			},
+			"range": [
+				0,
+				35
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 35
+				}
+			}
+		},
+		{
+			"type": "EmptyStatement",
+			"range": [
+				35,
+				36
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 35
+				},
+				"end": {
+					"line": 1,
+					"column": 36
+				}
+			}
+		}
+	],
+	"range": [
+		0,
+		36
+	],
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 1,
+			"column": 36
+		}
+	}
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous-extends.src.js
@@ -1,0 +1,1 @@
+export default class extends bar {};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.result.js
@@ -1,0 +1,90 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExportDefaultDeclaration",
+			"declaration": {
+				"type": "ClassDeclaration",
+				"id": null,
+				"superClass": null,
+				"body": {
+					"type": "ClassBody",
+					"body": [],
+					"range": [
+						21,
+						23
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 21
+						},
+						"end": {
+							"line": 1,
+							"column": 23
+						}
+					}
+				},
+				"range": [
+					15,
+					23
+				],
+				"loc": {
+					"start": {
+						"line": 1,
+						"column": 15
+					},
+					"end": {
+						"line": 1,
+						"column": 23
+					}
+				}
+			},
+            "range": [
+                0,
+                23
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            }
+        },
+        {
+            "type": "EmptyStatement",
+            "range": [
+                23,
+                24
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        24
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 24
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-anonymous.src.js
@@ -1,0 +1,1 @@
+export default class {};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.result.js
@@ -1,0 +1,124 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExportDefaultDeclaration",
+            "declaration": {
+                "type": "ClassDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "foo",
+                    "range": [
+                        21,
+                        24
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 21
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 24
+                        }
+                    }
+                },
+                "superClass": {
+                    "type": "Identifier",
+                    "name": "bar",
+                    "range": [
+                        33,
+                        36
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 33
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 36
+                        }
+                    }
+                },
+                "body": {
+                    "type": "ClassBody",
+                    "body": [],
+                    "range": [
+                        37,
+                        39
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 37
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 39
+                        }
+                    }
+                },
+                "range": [
+                    15,
+                    39
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 39
+                    }
+                }
+            },
+            "range": [
+                0,
+                39
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            }
+        },
+        {
+            "type": "EmptyStatement",
+            "range": [
+                39,
+                40
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 39
+                },
+                "end": {
+                    "line": 1,
+                    "column": 40
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        40
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 40
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default-extends.src.js
@@ -1,0 +1,1 @@
+export default class foo extends bar {};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.result.js
@@ -1,0 +1,107 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExportDefaultDeclaration",
+            "declaration": {
+                "type": "ClassDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "foo",
+                    "range": [
+                        21,
+                        24
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 21
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 24
+                        }
+                    }
+                },
+                "superClass": null,
+                "body": {
+                    "type": "ClassBody",
+                    "body": [],
+                    "range": [
+                        25,
+                        27
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 27
+                        }
+                    }
+                },
+                "range": [
+                    15,
+                    27
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 15
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 27
+                    }
+                }
+            },
+            "range": [
+                0,
+                27
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            }
+        },
+        {
+            "type": "EmptyStatement",
+            "range": [
+                27,
+                28
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        28
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 28
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-default.src.js
@@ -1,0 +1,1 @@
+export default class foo {};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.result.js
@@ -1,0 +1,126 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "declaration": {
+                "type": "ClassDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "foo",
+                    "range": [
+                        13,
+                        16
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 16
+                        }
+                    }
+                },
+                "superClass": {
+                    "type": "Identifier",
+                    "name": "bar",
+                    "range": [
+                        25,
+                        28
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 25
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 28
+                        }
+                    }
+                },
+                "body": {
+                    "type": "ClassBody",
+                    "body": [],
+                    "range": [
+                        29,
+                        31
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 29
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 31
+                        }
+                    }
+                },
+                "range": [
+                    7,
+                    31
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 31
+                    }
+                }
+            },
+            "specifiers": [],
+            "source": null,
+            "range": [
+                0,
+                31
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            }
+        },
+        {
+            "type": "EmptyStatement",
+            "range": [
+                31,
+                32
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 31
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        32
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 32
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class-extends.src.js
@@ -1,0 +1,1 @@
+export class foo extends bar {};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class.config.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    classes: true,
+    modules: true
+};

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class.result.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class.result.js
@@ -1,0 +1,109 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "declaration": {
+                "type": "ClassDeclaration",
+                "id": {
+                    "type": "Identifier",
+                    "name": "foo",
+                    "range": [
+                        13,
+                        16
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 13
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 16
+                        }
+                    }
+                },
+                "superClass": null,
+                "body": {
+                    "type": "ClassBody",
+                    "body": [],
+                    "range": [
+                        17,
+                        19
+                    ],
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 19
+                        }
+                    }
+                },
+                "range": [
+                    7,
+                    19
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 7
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 19
+                    }
+                }
+            },
+            "specifiers": [],
+            "source": null,
+            "range": [
+                0,
+                19
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            }
+        },
+        {
+            "type": "EmptyStatement",
+            "range": [
+                19,
+                20
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        20
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 20
+        }
+    }
+}

--- a/tests/fixtures/ecma-features-mix/modules-and-classes/class.src.js
+++ b/tests/fixtures/ecma-features-mix/modules-and-classes/class.src.js
@@ -1,0 +1,1 @@
+export class foo {};


### PR DESCRIPTION
Added tests for the following:
- [x] `export default class extends bar {};`
- [x] `export default class {};`
- [x] `export default class foo extends bar {};`
- [x] `export default class foo {};`
- [x] `export class foo extends bar {};`
- [x] `export class foo {};`

Fixed the following:
- [x] Provided a fix for `export default class foo extends bar {};` such that it would not `throw`

Need to check the following:
- [x] AST for `export default class {};` in `class-default-anonymous.result.js`
- [x] AST for `export default class foo extends bar {};` in `class-default-anonymous-extends.result.js`

The ASTs are tricky and need to be verified as accurate, because they were generated by espree.