### PR TITLE
Test: disallow import/export in function body

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -4888,6 +4888,9 @@ function parseExportAllDeclaration() {
 }
 
 function parseExportDeclaration() {
+    if (state.inFunctionBody) {
+        throwError({}, Messages.IllegalExportDeclaration);
+    }
     var declarationType = lookahead2().value;
     if (declarationType === "default") {
         return parseExportDefaultDeclaration();
@@ -4949,6 +4952,10 @@ function parseImportNamespaceSpecifier() {
 
 function parseImportDeclaration() {
     var specifiers, src, marker = markerCreate();
+
+    if (state.inFunctionBody) {
+        throwError({}, Messages.IllegalImportDeclaration);
+    }
 
     expectKeyword("import");
     specifiers = [];

--- a/tests/fixtures/ecma-features/modules/error-function.result.js
+++ b/tests/fixtures/ecma-features/modules/error-function.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 14,
+    "lineNumber": 1,
+    "column": 15,
+    "description": "Illegal export declaration"
+}

--- a/tests/fixtures/ecma-features/modules/error-function.src.js
+++ b/tests/fixtures/ecma-features/modules/error-function.src.js
@@ -1,0 +1,4 @@
+function x() {
+	export default friends;
+}
+

--- a/tests/fixtures/modules/import/error-function.result.js
+++ b/tests/fixtures/modules/import/error-function.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 16,
+    "lineNumber": 2,
+    "column": 2,
+    "description": "Illegal import declaration"
+};

--- a/tests/fixtures/modules/import/error-function.src.js
+++ b/tests/fixtures/modules/import/error-function.src.js
@@ -1,0 +1,4 @@
+function x() {
+	import friends from "friends";
+}
+


### PR DESCRIPTION
- 1 test for `import`
- 1 test for `export`

let me know if you think we ought to go into each of various permutations.
fat arrows might be a good idea as well.