### PR TITLE
Remove XJS note from Esprima-FB incompatibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ In an effort to help those wanting to transition from other parsers to Espree, t
 ### Esprima-FB
 
 * All Esprima/Harmony incompatibilities.
-* Esprima-FB uses the term "XJS" to refer to its JSX support. This is seen primarily in the AST node types, such as `"XJSElement"`. Espree uses "JSX" to refer to JSX functionality, including AST node types. So, `"XJSElement"` in Esprima-FB is `"JSXElement"` in Espree (and the same is true for all JSX-related node types).
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
The Esprima-FB project recently renamed all references of `XJS` to
`JSX`, so this should no longer be listed as an incompatibility.

- https://github.com/facebook/esprima/issues/83
- https://github.com/facebook/esprima/pull/85