### PR TITLE
Fix: generator methods in classes (fixes #85)

### DIFF
--- a/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.config.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	classes: true,
+	generators: true
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.result.js
@@ -1,0 +1,153 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "id": {
+                "type": "Identifier",
+                "name": "Foo",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                }
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "bar",
+                            "range": [
+                                14,
+                                17
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 5
+                                }
+                            }
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "params": [],
+                            "defaults": [],
+                            "body": {
+                                "type": "BlockStatement",
+                                "body": [],
+                                "range": [
+                                    20,
+                                    24
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 8
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    }
+                                }
+                            },
+                            "rest": null,
+                            "generator": true,
+                            "expression": false,
+                            "range": [
+                                17,
+                                24
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 2
+                                }
+                            }
+                        },
+                        "kind": "method",
+                        "computed": false,
+                        "range": [
+                            13,
+                            24
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 1
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 2
+                            }
+                        },
+                        "static": false
+                    }
+                ],
+                "range": [
+                    10,
+                    26
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 1
+                    }
+                }
+            },
+            "range": [
+                0,
+                26
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        26
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 4,
+            "column": 1
+        }
+    }
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.src.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/classes-and-generators.src.js
@@ -1,0 +1,4 @@
+class Foo {
+	*bar() {
+	}
+}

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.config.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	classes: true,
+	generators: false
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.result.js
@@ -1,0 +1,6 @@
+module.exports =  {
+	"index": 16,
+	"lineNumber": 2,
+	"column": 5,
+	"description": "Unexpected token *"
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.src.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-generator.src.js
@@ -1,0 +1,4 @@
+class Foo {
+    *bar() {
+    }
+}

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.config.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	classes: false,
+	objectLiteralShorthandMethods: false,
+	generators: false
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"index": 0,
+	"lineNumber": 1,
+	"column": 1,
+	"description": "Unexpected reserved word"
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.src.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-no-class.src.js
@@ -1,0 +1,4 @@
+class Foo {
+    *bar() {
+    }
+}

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.config.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	classes: true,
+	generators: false
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"index": 20,
+	"lineNumber": 2,
+	"column": 9,
+	"description": "Unexpected token *"
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.src.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/error-static-no-generators.src.js
@@ -1,0 +1,4 @@
+class Foo {
+	static *bar() {
+	}
+}

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.config.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	classes: true,
+	generators: true
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.result.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.result.js
@@ -1,0 +1,153 @@
+module.exports = {
+    "type": "Program",
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "id": {
+                "type": "Identifier",
+                "name": "Foo",
+                "range": [
+                    6,
+                    9
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 9
+                    }
+                }
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "body": [
+                    {
+                        "type": "MethodDefinition",
+                        "key": {
+                            "type": "Identifier",
+                            "name": "bar",
+                            "range": [
+                                21,
+                                24
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 2,
+                                    "column": 12
+                                }
+                            }
+                        },
+                        "value": {
+                            "type": "FunctionExpression",
+                            "id": null,
+                            "params": [],
+                            "defaults": [],
+                            "body": {
+                                "type": "BlockStatement",
+                                "body": [],
+                                "range": [
+                                    27,
+                                    31
+                                ],
+                                "loc": {
+                                    "start": {
+                                        "line": 2,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 3,
+                                        "column": 2
+                                    }
+                                }
+                            },
+                            "rest": null,
+                            "generator": true,
+                            "expression": false,
+                            "range": [
+                                24,
+                                31
+                            ],
+                            "loc": {
+                                "start": {
+                                    "line": 2,
+                                    "column": 12
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 2
+                                }
+                            }
+                        },
+                        "kind": "method",
+                        "computed": false,
+                        "range": [
+                            13,
+                            31
+                        ],
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 1
+                            },
+                            "end": {
+                                "line": 3,
+                                "column": 2
+                            }
+                        },
+                        "static": true
+                    }
+                ],
+                "range": [
+                    10,
+                    33
+                ],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 10
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 1
+                    }
+                }
+            },
+            "range": [
+                0,
+                33
+            ],
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 4,
+                    "column": 1
+                }
+            }
+        }
+    ],
+    "range": [
+        0,
+        33
+    ],
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 4,
+            "column": 1
+        }
+    }
+};

--- a/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.src.js
+++ b/tests/fixtures/ecma-features-mix/classes-and-generators/static-generators.src.js
@@ -1,0 +1,4 @@
+class Foo {
+	static *bar() {
+	}
+}

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.config.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    objectLiteralShorthandMethods: false,
+    generators: true
+};

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.result.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"index": 10,
+	"lineNumber": 1,
+	"column": 11,
+	"description": "Unexpected token *"
+};

--- a/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.src.js
+++ b/tests/fixtures/ecma-features-mix/objectLiteralShorthandMethods-and-generators/error-no-shorthand.src.js
@@ -1,0 +1,1 @@
+var x = { *test () { yield *v } };


### PR DESCRIPTION
- [x] supports generator methods in classes
- [x] supports static generator methods in classes
- [x] tests the success cases
- [x] tests to ensure failure when `generators` are `false`
- [x] tests to ensure failure when `generators` are `true` and `objectLiteralShorthandMethods` is `false`