### PR TITLE
Fix: bad error in parsing invalid class setter (fixes #98)

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -2435,7 +2435,7 @@ function tryParseMethodDefinition(token, key, computed, marker) {
                 rest: null
             };
             if (match(")")) {
-                throwErrorTolerant(lookahead, Messages.UnexpectedToken);
+                throwErrorTolerant(lookahead, Messages.UnexpectedToken, lookahead.value);
             } else {
                 parseParam(options);
                 if (options.defaultCount === 0) {

--- a/tests/fixtures/ecma-features/classes/invalid-class-setter-declaration.result.js
+++ b/tests/fixtures/ecma-features/classes/invalid-class-setter-declaration.result.js
@@ -1,0 +1,7 @@
+module.exports = {
+    "index": 18,
+    "lineNumber": 1,
+    "column": 19,
+    "message": "Line 1: Unexpected token )",
+    "description": "Unexpected token )"
+};

--- a/tests/fixtures/ecma-features/classes/invalid-class-setter-declaration.src.js
+++ b/tests/fixtures/ecma-features/classes/invalid-class-setter-declaration.src.js
@@ -1,0 +1,1 @@
+class A { set foo() {}};


### PR DESCRIPTION
I had some troubles getting a test to pass without resorting to the double definition of `message` and `description`, if you could provide some guidance I'd fix it.