### PR TITLE
Fix: Override ecmaFeatures with options, don't replace them

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -5272,7 +5272,9 @@ function tokenize(code, options) {
 
     // apply parsing flags
     if (options.ecmaFeatures && typeof options.ecmaFeatures === "object") {
-        extra.ecmaFeatures = options.ecmaFeatures;
+        Object.keys(options.ecmaFeatures).forEach(function(key) {
+            extra.ecmaFeatures[key] = options.ecmaFeatures[key];
+        });
     }
 
     try {
@@ -5406,15 +5408,9 @@ function parse(code, options) {
 
         // apply parsing flags after sourceType to allow overriding
         if (options.ecmaFeatures && typeof options.ecmaFeatures === "object") {
-
-            // if it's a module, augment the ecmaFeatures
-            if (options.sourceType === "module") {
-                Object.keys(options.ecmaFeatures).forEach(function(key) {
-                    extra.ecmaFeatures[key] = options.ecmaFeatures[key];
-                });
-            } else {
-                extra.ecmaFeatures = options.ecmaFeatures;
-            }
+            Object.keys(options.ecmaFeatures).forEach(function(key) {
+                extra.ecmaFeatures[key] = options.ecmaFeatures[key];
+            });
         }
 
     }


### PR DESCRIPTION
**Problem before this fix:**
E.g. `ecmaFeatures.blockBindings` is `true` by default, but using options `{ecmaFeatures:{}}` would cause all features to be `undefined`, causing the example below to throw an error:

```js
var espree = require('espree');
espree.parse('let a = 1', {ecmaFeatures: {}}); // Throws 'Unexpected token let'
```

----

I didn't see how this affects `espree.tokenize()`, but I figured I might as well provide the fix there too.

