### PR TITLE
Fix: Incomplete Switch Statement Hangs (Fixes #146)

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -4068,6 +4068,9 @@ function parseSwitchCase() {
             break;
         }
         statement = parseSourceElement();
+        if (typeof statement === "undefined") {
+            break;
+        }
         consequent.push(statement);
     }
 

--- a/tests/fixtures/ast/Invalid-syntax.json
+++ b/tests/fixtures/ast/Invalid-syntax.json
@@ -1324,5 +1324,11 @@
       "lineNumber": 1,
       "column": 27,
       "message": "Error: Line 1: Unexpected token )"
+    },
+    "switch(x) {  case 'x':  break;\n": {
+        "index": 31,
+        "lineNumber": 2,
+        "column": 1,
+        "message": "Error: Line 2: Unexpected end of input"
     }
 }


### PR DESCRIPTION
This fix follows a pattern used elsewhere in the codebase