### PR TITLE
Docs: added missing `ecmaFeatures.superInFunctions` option from doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ var ast = espree.parse(code, {
         // enable parsing spread operator
         spread: true,
 
+        // enable super in functions
+        superInFunctions: true,
+
         // enable parsing classes
         classes: true,
 


### PR DESCRIPTION
Related to https://github.com/eslint/espree/issues/153