### PR TITLE
Fix npm browserify

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -155,15 +155,10 @@ target.test = function() {
         lastReturn;
 
     lastReturn = nodeCLI.exec("istanbul", "cover", MOCHA, "-- -c", TEST_FILES);
-    // lastReturn = nodeCLI.exec("mocha", TEST_FILES);
+
     if (lastReturn.code !== 0) {
         errors++;
     }
-
-    // lastReturn = nodeCLI.exec("istanbul", "check-coverage", "--statement 99 --branch 98 --function 99 --lines 99");
-    // if (lastReturn.code !== 0) {
-    //     errors++;
-    // }
 
     if (errors) {
         exit(1);
@@ -193,6 +188,8 @@ target.browserify = function() {
     // 2. copy files into temp directory
     cp("-r", "lib/*", TEMP_DIR + "/lib");
     cp("espree.js", TEMP_DIR);
+    cp("package.json", TEMP_DIR);
+
 
     // 3. browserify the temp directory
     nodeCLI.exec("browserify", TEMP_DIR + "espree.js", "-o", BUILD_DIR + "espree.js", "-s espree");


### PR DESCRIPTION
When I ran `npm run browserify` I got this error. The fix seemed to be to copy `package.json` into `tmp`. Have you seen this before?

```
➜  espree git:(cleanup-makefile) ✗ npm run browserify

> espree@2.0.4 browserify /Users/jlaster/src/_os/_js/espree
> node Makefile.js browserify

Error: Cannot find module './package.json' from '/Users/jlaster/src/_os/_js/espree/tmp'
    at /Users/jlaster/src/_os/_js/espree/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:55:21
    at load (/Users/jlaster/src/_os/_js/espree/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/jlaster/src/_os/_js/espree/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:92:31)
    at /Users/jlaster/src/_os/_js/espree/node_modules/browserify/node_modules/browser-resolve/node_modules/resolve/lib/async.js:22:47
```

I also included some red `npm test` code because to the outsider it looks like you commented out your tests, whichi is not the case :)