### PR TITLE
Fix: tests for importing keywords (fixes #225)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "license": "BSD-2-Clause",
   "devDependencies": {
+    "acorn": "^2.7.0",
     "browserify": "^7.0.0",
     "chai": "^1.10.0",
     "complexity-report": "~0.6.1",

--- a/tests/fixtures/ecma-version/6/modules/import-named-as-specifier-keyword.result.js
+++ b/tests/fixtures/ecma-version/6/modules/import-named-as-specifier-keyword.result.js
@@ -1,0 +1,275 @@
+module.exports = {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 31
+        }
+    },
+    "range": [
+        0,
+        31
+    ],
+    "body": [
+        {
+            "type": "ImportDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "range": [
+                0,
+                31
+            ],
+            "specifiers": [
+                {
+                    "type": "ImportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        8,
+                        18
+                    ],
+                    "imported": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            8,
+                            11
+                        ],
+                        "name": "var"
+                    },
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 15
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 18
+                            }
+                        },
+                        "range": [
+                            15,
+                            18
+                        ],
+                        "name": "baz"
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 25
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 30
+                    }
+                },
+                "range": [
+                    25,
+                    30
+                ],
+                "value": "foo",
+                "raw": "\"foo\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "import",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            },
+            "range": [
+                8,
+                11
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                12,
+                14
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "baz",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "range": [
+                15,
+                18
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                18,
+                19
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                20,
+                24
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"foo\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                25,
+                30
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "range": [
+                30,
+                31
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/6/modules/import-named-as-specifier-keyword.src.js
+++ b/tests/fixtures/ecma-version/6/modules/import-named-as-specifier-keyword.src.js
@@ -1,0 +1,1 @@
+import {var as baz} from "foo";

--- a/tests/fixtures/ecma-version/6/modules/invalid-import-named-as-keyword.result.js
+++ b/tests/fixtures/ecma-version/6/modules/invalid-import-named-as-keyword.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 15,
+    "lineNumber": 1,
+    "column": 16,
+    "message": "Unexpected token var"
+};

--- a/tests/fixtures/ecma-version/6/modules/invalid-import-named-as-keyword.src.js
+++ b/tests/fixtures/ecma-version/6/modules/invalid-import-named-as-keyword.src.js
@@ -1,0 +1,1 @@
+import {foo as var} from "foo"

--- a/tests/fixtures/ecma-version/6/modules/invalid-import-named-keyword.result.js
+++ b/tests/fixtures/ecma-version/6/modules/invalid-import-named-keyword.result.js
@@ -1,0 +1,6 @@
+module.exports = {
+    "index": 8,
+    "lineNumber": 1,
+    "column": 9,
+    "message": "Unexpected token var"
+};

--- a/tests/fixtures/ecma-version/6/modules/invalid-import-named-keyword.src.js
+++ b/tests/fixtures/ecma-version/6/modules/invalid-import-named-keyword.src.js
@@ -1,0 +1,1 @@
+import {var} from "foo"


### PR DESCRIPTION
fixes #225.

I fixed this in https://github.com/ternjs/acorn/commit/327d631aa38c75c1d8a97bcb6ba3aca4a148464f
So I just add tests for this.

The test of `ecma-version/6/modules/invalid-import-named-keyword` had been failing with `acorn@2.6.4`.
Then the test gets passing with `acorn@2.7.0`.