### PR TITLE
Fix: use the plugins feature of acorn (fixes #250)

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -96,8 +96,6 @@ function resetExtra() {
 
 
 var tt = acorn.tokTypes,
-    Parser = acorn.Parser,
-    pp = Parser.prototype,
     getLineInfo = acorn.getLineInfo;
 
 // custom type for JSX attribute values
@@ -235,215 +233,218 @@ function wrapFinishNode(finishNode) {
     };
 }
 
-pp.extend("finishNode", wrapFinishNode);
+acorn.plugins.espree = function(instance) {
 
-pp.extend("finishNodeAt", wrapFinishNode);
+    instance.extend("finishNode", wrapFinishNode);
 
-pp.extend("next", function(next) {
-    return /** @this acorn.Parser */ function() {
-        if (!isValidToken(this)) {
-            this.unexpected();
-        }
-        return next.call(this);
-    };
-});
+    instance.extend("finishNodeAt", wrapFinishNode);
 
-// needed for experimental object rest/spread
-pp.extend("checkLVal", function(checkLVal) {
+    instance.extend("next", function(next) {
+        return /** @this acorn.Parser */ function() {
+            if (!isValidToken(this)) {
+                this.unexpected();
+            }
+            return next.call(this);
+        };
+    });
 
-    return /** @this acorn.Parser */ function(expr, isBinding, checkClashes) {
+    // needed for experimental object rest/spread
+    instance.extend("checkLVal", function(checkLVal) {
 
-        if (extra.ecmaFeatures.experimentalObjectRestSpread && expr.type === "ObjectPattern") {
-            for (var i = 0; i < expr.properties.length; i++) {
-                if (expr.properties[i].type.indexOf("Experimental") === -1) {
-                    this.checkLVal(expr.properties[i].value, isBinding, checkClashes);
+        return /** @this acorn.Parser */ function(expr, isBinding, checkClashes) {
+
+            if (extra.ecmaFeatures.experimentalObjectRestSpread && expr.type === "ObjectPattern") {
+                for (var i = 0; i < expr.properties.length; i++) {
+                    if (expr.properties[i].type.indexOf("Experimental") === -1) {
+                        this.checkLVal(expr.properties[i].value, isBinding, checkClashes);
+                    }
                 }
+                return undefined;
             }
-            return undefined;
-        }
 
-        return checkLVal.call(this, expr, isBinding, checkClashes);
-    };
-});
+            return checkLVal.call(this, expr, isBinding, checkClashes);
+        };
+    });
 
-pp.extend("parseTopLevel", function(parseTopLevel) {
-    return /** @this acorn.Parser */ function(node) {
-        if (extra.ecmaFeatures.impliedStrict && this.options.ecmaVersion >= 5) {
-            this.strict = true;
-        }
-        return parseTopLevel.call(this, node);
-    };
-});
+    instance.extend("parseTopLevel", function(parseTopLevel) {
+        return /** @this acorn.Parser */ function(node) {
+            if (extra.ecmaFeatures.impliedStrict && this.options.ecmaVersion >= 5) {
+                this.strict = true;
+            }
+            return parseTopLevel.call(this, node);
+        };
+    });
 
-pp.extend("toAssignable", function(toAssignable) {
+    instance.extend("toAssignable", function(toAssignable) {
 
-    return /** @this acorn.Parser */ function(node, isBinding) {
+        return /** @this acorn.Parser */ function(node, isBinding) {
 
-        if (extra.ecmaFeatures.experimentalObjectRestSpread &&
-                node.type === "ObjectExpression"
-        ) {
-            node.type = "ObjectPattern";
+            if (extra.ecmaFeatures.experimentalObjectRestSpread &&
+                    node.type === "ObjectExpression"
+            ) {
+                node.type = "ObjectPattern";
 
-            for (var i = 0; i < node.properties.length; i++) {
-                var prop = node.properties[i];
+                for (var i = 0; i < node.properties.length; i++) {
+                    var prop = node.properties[i];
 
-                if (prop.type === "ExperimentalSpreadProperty") {
-                    prop.type = "ExperimentalRestProperty";
-                } else if (prop.kind !== "init") {
-                    this.raise(prop.key.start, "Object pattern can't contain getter or setter");
-                } else {
-                    this.toAssignable(prop.value, isBinding);
+                    if (prop.type === "ExperimentalSpreadProperty") {
+                        prop.type = "ExperimentalRestProperty";
+                    } else if (prop.kind !== "init") {
+                        this.raise(prop.key.start, "Object pattern can't contain getter or setter");
+                    } else {
+                        this.toAssignable(prop.value, isBinding);
+                    }
                 }
-            }
 
-            return node;
-        } else {
-            return toAssignable.call(this, node, isBinding);
-        }
-    };
-
-});
-
-/**
- * Method to parse an object rest or object spread.
- * @returns {ASTNode} The node representing object rest or object spread.
- * @this acorn.Parser
- */
-pp.parseObjectRest = function() {
-    var node = this.startNode();
-    this.next();
-    node.argument = this.parseIdent();
-    return this.finishNode(node, "ExperimentalRestProperty");
-};
-
-/**
- * Method to parse an object with object rest or object spread.
- * @param {boolean} isPattern True if the object is a destructuring pattern.
- * @param {Object} refShorthandDefaultPos ?
- * @returns {ASTNode} The node representing object rest or object spread.
- * @this acorn.Parser
- */
-pp.parseObj = function(isPattern, refShorthandDefaultPos) {
-    var node = this.startNode(),
-        first = true,
-        propHash = {};
-    node.properties = [];
-    this.next();
-    while (!this.eat(tt.braceR)) {
-
-        if (!first) {
-            this.expect(tt.comma);
-
-            if (this.afterTrailingComma(tt.braceR)) {
-                break;
-            }
-
-        } else {
-            first = false;
-        }
-
-        var prop = this.startNode(),
-            isGenerator,
-            startPos,
-            startLoc;
-
-        if (extra.ecmaFeatures.experimentalObjectRestSpread && this.type === tt.ellipsis) {
-            if (isPattern) {
-                prop = this.parseObjectRest();
+                return node;
             } else {
-                prop = this.parseSpread();
-                prop.type = "ExperimentalSpreadProperty";
+                return toAssignable.call(this, node, isBinding);
             }
+        };
 
-            node.properties.push(prop);
-            continue;
-        }
+    });
 
-        if (this.options.ecmaVersion >= 6) {
-            prop.method = false;
-            prop.shorthand = false;
-
-            if (isPattern || refShorthandDefaultPos) {
-                startPos = this.start;
-                startLoc = this.startLoc;
-            }
-
-            if (!isPattern) {
-                isGenerator = this.eat(tt.star);
-            }
-        }
-
-        this.parsePropertyName(prop);
-        this.parsePropertyValue(prop, isPattern, isGenerator, startPos, startLoc, refShorthandDefaultPos);
-        this.checkPropClash(prop, propHash);
-        node.properties.push(this.finishNode(prop, "Property"));
-    }
-
-    return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
-};
-
-/**
- * Overwrites the default raise method to throw Esprima-style errors.
- * @param {int} pos The position of the error.
- * @param {string} message The error message.
- * @throws {SyntaxError} A syntax error.
- * @returns {void}
- */
-pp.raise = function(pos, message) {
-    var loc = getLineInfo(this.input, pos);
-    var err = new SyntaxError(message);
-    err.index = pos;
-    err.lineNumber = loc.line;
-    err.column = loc.column + 1; // acorn uses 0-based columns
-    throw err;
-};
-
-/**
- * Overwrites the default unexpected method to throw Esprima-style errors.
- * @param {int} pos The position of the error.
- * @throws {SyntaxError} A syntax error.
- * @returns {void}
- */
-pp.unexpected = function(pos) {
-    var message = "Unexpected token";
-
-    if (pos !== null && pos !== undefined) {
-        this.pos = pos;
-
-        if (this.options.locations) {
-            while (this.pos < this.lineStart) {
-                this.lineStart = this.input.lastIndexOf("\n", this.lineStart - 2) + 1;
-                --this.curLine;
-            }
-        }
-
-        this.nextToken();
-    }
-
-    if (this.end > this.start) {
-        message += " " + this.input.slice(this.start, this.end);
-    }
-
-    this.raise(this.start, message);
-};
-
-/*
- * Esprima-FB represents JSX strings as tokens called "JSXText", but Acorn-JSX
- * uses regular tt.string without any distinction between this and regular JS
- * strings. As such, we intercept an attempt to read a JSX string and set a flag
- * on extra so that when tokens are converted, the next token will be switched
- * to JSXText via onToken.
- */
-pp.extend("jsx_readString", function(jsxReadString) {
-    return /** @this acorn.Parser */ function(quote) {
-        var result = jsxReadString.call(this, quote);
-        if (this.type === tt.string) {
-            extra.jsxAttrValueToken = true;
-        }
-
-        return result;
+    /**
+     * Method to parse an object rest or object spread.
+     * @returns {ASTNode} The node representing object rest or object spread.
+     * @this acorn.Parser
+     */
+    instance.parseObjectRest = function() {
+        var node = this.startNode();
+        this.next();
+        node.argument = this.parseIdent();
+        return this.finishNode(node, "ExperimentalRestProperty");
     };
-});
+
+    /**
+     * Method to parse an object with object rest or object spread.
+     * @param {boolean} isPattern True if the object is a destructuring pattern.
+     * @param {Object} refShorthandDefaultPos ?
+     * @returns {ASTNode} The node representing object rest or object spread.
+     * @this acorn.Parser
+     */
+    instance.parseObj = function(isPattern, refShorthandDefaultPos) {
+        var node = this.startNode(),
+            first = true,
+            propHash = {};
+        node.properties = [];
+        this.next();
+        while (!this.eat(tt.braceR)) {
+
+            if (!first) {
+                this.expect(tt.comma);
+
+                if (this.afterTrailingComma(tt.braceR)) {
+                    break;
+                }
+
+            } else {
+                first = false;
+            }
+
+            var prop = this.startNode(),
+                isGenerator,
+                startPos,
+                startLoc;
+
+            if (extra.ecmaFeatures.experimentalObjectRestSpread && this.type === tt.ellipsis) {
+                if (isPattern) {
+                    prop = this.parseObjectRest();
+                } else {
+                    prop = this.parseSpread();
+                    prop.type = "ExperimentalSpreadProperty";
+                }
+
+                node.properties.push(prop);
+                continue;
+            }
+
+            if (this.options.ecmaVersion >= 6) {
+                prop.method = false;
+                prop.shorthand = false;
+
+                if (isPattern || refShorthandDefaultPos) {
+                    startPos = this.start;
+                    startLoc = this.startLoc;
+                }
+
+                if (!isPattern) {
+                    isGenerator = this.eat(tt.star);
+                }
+            }
+
+            this.parsePropertyName(prop);
+            this.parsePropertyValue(prop, isPattern, isGenerator, startPos, startLoc, refShorthandDefaultPos);
+            this.checkPropClash(prop, propHash);
+            node.properties.push(this.finishNode(prop, "Property"));
+        }
+
+        return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+    };
+
+    /**
+     * Overwrites the default raise method to throw Esprima-style errors.
+     * @param {int} pos The position of the error.
+     * @param {string} message The error message.
+     * @throws {SyntaxError} A syntax error.
+     * @returns {void}
+     */
+    instance.raise = function(pos, message) {
+        var loc = getLineInfo(this.input, pos);
+        var err = new SyntaxError(message);
+        err.index = pos;
+        err.lineNumber = loc.line;
+        err.column = loc.column + 1; // acorn uses 0-based columns
+        throw err;
+    };
+
+    /**
+     * Overwrites the default unexpected method to throw Esprima-style errors.
+     * @param {int} pos The position of the error.
+     * @throws {SyntaxError} A syntax error.
+     * @returns {void}
+     */
+    instance.unexpected = function(pos) {
+        var message = "Unexpected token";
+
+        if (pos !== null && pos !== undefined) {
+            this.pos = pos;
+
+            if (this.options.locations) {
+                while (this.pos < this.lineStart) {
+                    this.lineStart = this.input.lastIndexOf("\n", this.lineStart - 2) + 1;
+                    --this.curLine;
+                }
+            }
+
+            this.nextToken();
+        }
+
+        if (this.end > this.start) {
+            message += " " + this.input.slice(this.start, this.end);
+        }
+
+        this.raise(this.start, message);
+    };
+
+    /*
+    * Esprima-FB represents JSX strings as tokens called "JSXText", but Acorn-JSX
+    * uses regular tt.string without any distinction between this and regular JS
+    * strings. As such, we intercept an attempt to read a JSX string and set a flag
+    * on extra so that when tokens are converted, the next token will be switched
+    * to JSXText via onToken.
+    */
+    instance.extend("jsx_readString", function(jsxReadString) {
+        return /** @this acorn.Parser */ function(quote) {
+            var result = jsxReadString.call(this, quote);
+            if (this.type === tt.string) {
+                extra.jsxAttrValueToken = true;
+            }
+
+            return result;
+        };
+    });
+};
 
 //------------------------------------------------------------------------------
 // Tokenizer
@@ -474,7 +475,10 @@ function tokenize(code, options) {
     options = options || {};
 
     var acornOptions = {
-        ecmaVersion: 5
+        ecmaVersion: 5,
+        plugins: {
+            espree: true
+        }
     };
 
     resetExtra();
@@ -595,7 +599,10 @@ function parse(code, options) {
         translator,
         impliedStrict,
         acornOptions = {
-            ecmaVersion: 5
+            ecmaVersion: 5,
+            plugins: {
+                espree: true
+            }
         };
 
     lastToken = null;
@@ -699,7 +706,11 @@ function parse(code, options) {
         }
 
         if (extra.ecmaFeatures.jsx) {
-            acornOptions.plugins = { jsx: true };
+            // Should process jsx plugin before espree plugin.
+            acornOptions.plugins = {
+                jsx: true,
+                espree: true
+            };
         }
     }
 

--- a/tests/lib/acorn-after-espree.js
+++ b/tests/lib/acorn-after-espree.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Tests for checking acorn works after espree was loaded.
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var acorn = require("acorn"),
+    assert = require("chai").assert;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("acorn", function() {
+    it("acorn.parse() should work after espree was loaded.", function() {
+        var before = acorn.parse("var foo = bar /*world*/;");
+        require("../../espree");
+        var after = acorn.parse("var foo = bar /*world*/;");
+
+        assert.deepEqual(after, before);
+    });
+});


### PR DESCRIPTION
fixes #250

This PR contains indent changes, so `?w=1` would help to see actual changes.