### PR TITLE
Fix: Fix behavior of ignoring comments within previous nodes (refs #256)

### DIFF
--- a/lib/comment-attachment.js
+++ b/lib/comment-attachment.js
@@ -43,6 +43,40 @@ var extra = {
     bottomRightStack: []
 };
 
+/** Recursively remove leading comments that are incorrectly added when no
+ * expression exists between comment and the current node
+ * @param {node} node to recursively check
+ * @returns {void}
+ */
+function removeExtraLeadingComments(node) {
+    var i, j;
+
+    if (!node.body) {
+        return;
+    }
+
+    if (Array.isArray(node.body)) {
+        // i must start at 0 so that we can check all indices recursively
+        for (i = 0; i < node.body.length; i++) {
+            // i must be greater than 0 to perform the check on the previous node
+            if (i > 0 && node.body[i].leadingComments) {
+                for (j = 0; j < node.body[i].leadingComments.length; j++) {
+                    if (node.body[i].leadingComments[j].range[1] < node.body[i - 1].range[1]) {
+                        node.body[i].leadingComments.splice(j, 1);
+                    }
+                }
+
+                if (node.body[i].leadingComments.length === 0) {
+                    delete node.body[i].leadingComments;
+                }
+            }
+            removeExtraLeadingComments(node.body[i]);
+        }
+    } else {
+        removeExtraLeadingComments(node.body);
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public
 //------------------------------------------------------------------------------
@@ -63,25 +97,10 @@ module.exports = {
     processComment: function(node) {
         var lastChild,
             trailingComments,
-            i,
-            j;
+            i;
 
         if (node.type === astNodeTypes.Program) {
-            // Remove leading comments that are incorrectly added when no expression exists
-            // between comment and the current node
-            for (i = 1; i < node.body.length; i++) {
-                if (node.body[i].leadingComments) {
-                    for (j = 0; j < node.body[i].leadingComments.length; j++) {
-                        if (node.body[i].leadingComments[j].range[1] < node.body[i - 1].range[1]) {
-                            node.body[i].leadingComments.splice(j, 1);
-                        }
-                    }
-
-                    if (node.body[i].leadingComments.length === 0) {
-                        delete node.body[i].leadingComments;
-                    }
-                }
-            }
+            removeExtraLeadingComments(node);
 
             if (node.body.length > 0) {
                 return;

--- a/tests/fixtures/attach-comments/comment-within-previous-node2.result.js
+++ b/tests/fixtures/attach-comments/comment-within-previous-node2.result.js
@@ -1,0 +1,389 @@
+module.exports = {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 6,
+            "column": 1
+        }
+    },
+    "range": [0, 70],
+    "body": [{
+        "type": "FunctionDeclaration",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 6,
+                "column": 1
+            }
+        },
+        "range": [0, 70],
+        "id": {
+            "type": "Identifier",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            },
+            "range": [9, 10],
+            "name": "a"
+        },
+        "params": [],
+        "body": {
+            "type": "BlockStatement",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 6,
+                    "column": 1
+                }
+            },
+            "range": [13, 70],
+            "body": [{
+                "type": "VariableDeclaration",
+                "loc": {
+                    "start": {
+                        "line": 2,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 4,
+                        "column": 6
+                    }
+                },
+                "range": [19, 54],
+                "declarations": [{
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 8
+                        },
+                        "end": {
+                            "line": 4,
+                            "column": 5
+                        }
+                    },
+                    "range": [23, 53],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 8
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 9
+                            }
+                        },
+                        "range": [23, 24],
+                        "name": "b"
+                    },
+                    "init": {
+                        "type": "ObjectExpression",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 4,
+                                "column": 5
+                            }
+                        },
+                        "range": [27, 53],
+                        "properties": [],
+                        "trailingComments": [{
+                            "type": "Line",
+                            "value": " comment",
+                            "range": [37, 47],
+                            "loc": {
+                                "start": {
+                                    "line": 3,
+                                    "column": 8
+                                },
+                                "end": {
+                                    "line": 3,
+                                    "column": 18
+                                }
+                            }
+                        }]
+                    }
+                }],
+                "kind": "var"
+            }, {
+                "type": "ReturnStatement",
+                "loc": {
+                    "start": {
+                        "line": 5,
+                        "column": 4
+                    },
+                    "end": {
+                        "line": 5,
+                        "column": 13
+                    }
+                },
+                "range": [59, 68],
+                "argument": {
+                    "type": "Identifier",
+                    "loc": {
+                        "start": {
+                            "line": 5,
+                            "column": 11
+                        },
+                        "end": {
+                            "line": 5,
+                            "column": 12
+                        }
+                    },
+                    "range": [66, 67],
+                    "name": "b"
+                }
+            }]
+        },
+        "expression": false,
+        "generator": false
+    }],
+    "sourceType": "script",
+    "comments": [{
+        "type": "Line",
+        "value": " comment",
+        "range": [37, 47],
+        "loc": {
+            "start": {
+                "line": 3,
+                "column": 8
+            },
+            "end": {
+                "line": 3,
+                "column": 18
+            }
+        }
+    }],
+    "tokens": [{
+        "type": "Keyword",
+        "value": "function",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 0
+            },
+            "end": {
+                "line": 1,
+                "column": 8
+            }
+        },
+        "range": [0, 8]
+    }, {
+        "type": "Identifier",
+        "value": "a",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 9
+            },
+            "end": {
+                "line": 1,
+                "column": 10
+            }
+        },
+        "range": [9, 10]
+    }, {
+        "type": "Punctuator",
+        "value": "(",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 10
+            },
+            "end": {
+                "line": 1,
+                "column": 11
+            }
+        },
+        "range": [10, 11]
+    }, {
+        "type": "Punctuator",
+        "value": ")",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 11
+            },
+            "end": {
+                "line": 1,
+                "column": 12
+            }
+        },
+        "range": [11, 12]
+    }, {
+        "type": "Punctuator",
+        "value": "{",
+        "loc": {
+            "start": {
+                "line": 1,
+                "column": 13
+            },
+            "end": {
+                "line": 1,
+                "column": 14
+            }
+        },
+        "range": [13, 14]
+    }, {
+        "type": "Keyword",
+        "value": "var",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 4
+            },
+            "end": {
+                "line": 2,
+                "column": 7
+            }
+        },
+        "range": [19, 22]
+    }, {
+        "type": "Identifier",
+        "value": "b",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 8
+            },
+            "end": {
+                "line": 2,
+                "column": 9
+            }
+        },
+        "range": [23, 24]
+    }, {
+        "type": "Punctuator",
+        "value": "=",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 10
+            },
+            "end": {
+                "line": 2,
+                "column": 11
+            }
+        },
+        "range": [25, 26]
+    }, {
+        "type": "Punctuator",
+        "value": "{",
+        "loc": {
+            "start": {
+                "line": 2,
+                "column": 12
+            },
+            "end": {
+                "line": 2,
+                "column": 13
+            }
+        },
+        "range": [27, 28]
+    }, {
+        "type": "Punctuator",
+        "value": "}",
+        "loc": {
+            "start": {
+                "line": 4,
+                "column": 4
+            },
+            "end": {
+                "line": 4,
+                "column": 5
+            }
+        },
+        "range": [52, 53]
+    }, {
+        "type": "Punctuator",
+        "value": ";",
+        "loc": {
+            "start": {
+                "line": 4,
+                "column": 5
+            },
+            "end": {
+                "line": 4,
+                "column": 6
+            }
+        },
+        "range": [53, 54]
+    }, {
+        "type": "Keyword",
+        "value": "return",
+        "loc": {
+            "start": {
+                "line": 5,
+                "column": 4
+            },
+            "end": {
+                "line": 5,
+                "column": 10
+            }
+        },
+        "range": [59, 65]
+    }, {
+        "type": "Identifier",
+        "value": "b",
+        "loc": {
+            "start": {
+                "line": 5,
+                "column": 11
+            },
+            "end": {
+                "line": 5,
+                "column": 12
+            }
+        },
+        "range": [66, 67]
+    }, {
+        "type": "Punctuator",
+        "value": ";",
+        "loc": {
+            "start": {
+                "line": 5,
+                "column": 12
+            },
+            "end": {
+                "line": 5,
+                "column": 13
+            }
+        },
+        "range": [67, 68]
+    }, {
+        "type": "Punctuator",
+        "value": "}",
+        "loc": {
+            "start": {
+                "line": 6,
+                "column": 0
+            },
+            "end": {
+                "line": 6,
+                "column": 1
+            }
+        },
+        "range": [69, 70]
+    }]
+};

--- a/tests/fixtures/attach-comments/comment-within-previous-node2.src.js
+++ b/tests/fixtures/attach-comments/comment-within-previous-node2.src.js
@@ -1,0 +1,6 @@
+function a() {
+    var b = {
+        // comment
+    };
+    return b;
+}


### PR DESCRIPTION
While adding tests to the main ESLint repo to account for the changes I made in https://github.com/eslint/espree/pull/257 I realized that some of my initial assumptions were wrong:
 - That the `body` prop is always an array (in reality it can be an array or an object)
 - I didn't check the `body` props recursively (I had incorrectly thought the `Program` node's `body` contained all the nodes, which, in retrospect, is pretty silly)

This means that my current merged fix does not account for this case, as the comment to remove is nested a few levels deep, with the `body` props being a mixture of arrays and objects as you drill down:
```js
function a() {
    var b = {
        // comment
    };
    return b;
}
```
I'm going to test out the main ESLint repo with this branch now, but wanted to see if I could get some eyes on this to see if it made sense. Thanks!