### PR TITLE
Build: replace optimist with a simple native method

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "json-diff": "~0.3.1",
     "leche": "^1.0.1",
     "mocha": "^2.0.1",
-    "optimist": "~0.6.0",
     "regenerate": "~0.5.4",
     "shelljs": "^0.3.0",
     "shelljs-nodecli": "^0.1.1",

--- a/tools/generate-test-fixture.js
+++ b/tools/generate-test-fixture.js
@@ -30,7 +30,6 @@
 (function () {
     'use strict';
     var fs = require('fs'),
-        optimist = require('optimist'),
         path = require('path'),
         root = path.join(path.dirname(fs.realpathSync(__filename)), '..'),
         espree = require(path.join(root, 'espree')),
@@ -330,7 +329,7 @@
 
     console.log(stringify(
         espree.parse(content, options),
-        !!optimist.argv['strict-json']
+        process.argv.indexOf('strict-json') !== -1
     ));
 }());
 /* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
Because:

1. [`optimist`](https://www.npmjs.com/package/optimist) package was [deprecated](https://github.com/substack/node-optimist/commit/815c965cee7682ae2c6a80f8b306d20c81eb199a)  long ago.
2. It can be replaced with a simple, enough readable native method.

Otherwise, I recommend to use [minimist](https://www.npmjs.com/package/minimist) instead.
