### PR TITLE
Docs: replace a dead link with the correct contributing guide URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ Please sign our [Contributor License Agreement](http://eslint.org/cla)
 # Full Documentation
 
 Our full contribution guidelines can be found at:
-http://eslint.org/docs/developer-guide/contributing.html
+<http://eslint.org/docs/developer-guide/contributing/>


### PR DESCRIPTION
Currently http://eslint.org/docs/developer-guide/contributing.html returns 404.
