### PR TITLE
Fix: `}` token followed by template had been lost (fixes #293)

### DIFF
--- a/lib/token-translator.js
+++ b/lib/token-translator.js
@@ -201,6 +201,13 @@ TokenTranslator.prototype = {
         }
 
         if (token.type === tt.backQuote) {
+
+            // if there's already a curly, it's not part of the template
+            if (this._curlyBrace) {
+                tokens.push(this.translate(this._curlyBrace, extra));
+                this._curlyBrace = null;
+            }
+
             templateTokens.push(token);
 
             // it's the end
@@ -217,7 +224,6 @@ TokenTranslator.prototype = {
 
             // if there's already a curly, it's not part of the template
             if (this._curlyBrace) {
-
                 tokens.push(this.translate(this._curlyBrace, extra));
             }
 

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -149,4 +149,37 @@ describe("tokenize()", function() {
         assert.deepEqual(tester.getRaw(tokens), [ { type: "Identifier", value: "a"}]);
     });
 
+    it("should not remove } token followed by a template literal.", function() {
+        var tokens = espree.tokenize("const obj = {}\n`template${{}}!`", {ecmaVersion: 6});
+        assert.deepEqual(
+            tester.getRaw(tokens),
+            [
+                {type: "Keyword", value: "const"},
+                {type: "Identifier", value: "obj"},
+                {type: "Punctuator", value: "="},
+                {type: "Punctuator", value: "{"},
+                {type: "Punctuator", value: "}"},
+                {type: "Template", value: "`template${"},
+                {type: "Punctuator", value: "{"},
+                {type: "Punctuator", value: "}"},
+                {type: "Template", value: "}!`"}
+            ]
+        );
+
+        tokens = espree.tokenize("if (a) { b }\n`template`", {ecmaVersion: 6});
+        assert.deepEqual(
+            tester.getRaw(tokens),
+            [
+                {type: "Keyword", value: "if"},
+                {type: "Punctuator", value: "("},
+                {type: "Identifier", value: "a"},
+                {type: "Punctuator", value: ")"},
+                {type: "Punctuator", value: "{"},
+                {type: "Identifier", value: "b"},
+                {type: "Punctuator", value: "}"},
+                {type: "Template", value: "`template`"}
+            ]
+        );
+    });
+
 });


### PR DESCRIPTION
Fixes #293.

Espree does not handle the previous `}` token at the first back quote of a template literal. As a result, the template literal is made from [ <code>\`</code>, `}`, `template`, <code>\`</code> ] sequence. The 2nd item `}` is the lost `}` token.

This PR makes espree handling the previous `}` token at the first back quote of a template literal.