### PR TITLE
Fix: classify `await` tokens as keywords (fixes #304)

### DIFF
--- a/lib/token-translator.js
+++ b/lib/token-translator.js
@@ -110,7 +110,7 @@ TokenTranslator.prototype = {
                 token.type = Token.Keyword;
             }
 
-            if (extra.ecmaVersion > 5 && (token.value === "yield" || token.value === "let")) {
+            if (extra.ecmaVersion > 5 && (token.value === "yield" || token.value === "let" || token.value === "await")) {
                 token.type = Token.Keyword;
             }
 

--- a/tests/fixtures/ecma-version/6/modules/valid-await.result.js
+++ b/tests/fixtures/ecma-version/6/modules/valid-await.result.js
@@ -126,7 +126,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-arrow-func-parens.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-arrow-func-parens.result.js
@@ -309,7 +309,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-arrow-expression.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-arrow-expression.result.js
@@ -220,7 +220,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-arrow-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-arrow-param.result.js
@@ -366,7 +366,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-class-method-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-class-method-param.result.js
@@ -532,7 +532,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-destructured-default.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-destructured-default.result.js
@@ -455,7 +455,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-expression-class-method.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-expression-class-method.result.js
@@ -386,7 +386,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-function-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-function-param.result.js
@@ -455,7 +455,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-identifier-math.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-identifier-math.result.js
@@ -274,7 +274,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-inside-parens.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-inside-parens.result.js
@@ -344,7 +344,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-math.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-math.result.js
@@ -398,7 +398,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {
@@ -452,7 +452,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-named-object-method.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-named-object-method.result.js
@@ -188,7 +188,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-object-method-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-object-method-param.result.js
@@ -496,7 +496,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await-object-method.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await-object-method.result.js
@@ -350,7 +350,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-await.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-await.result.js
@@ -345,7 +345,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-class-method-named-await.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-class-method-named-await.result.js
@@ -241,7 +241,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/modules/async-static-class-method-named-await.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-static-class-method-named-await.result.js
@@ -259,7 +259,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-arrow-func-parens.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-arrow-func-parens.result.js
@@ -309,7 +309,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-arrow-expression.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-arrow-expression.result.js
@@ -220,7 +220,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-arrow-param.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-arrow-param.result.js
@@ -366,7 +366,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-class-method-param.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-class-method-param.result.js
@@ -532,7 +532,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-destructured-default.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-destructured-default.result.js
@@ -455,7 +455,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-expression-class-method.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-expression-class-method.result.js
@@ -386,7 +386,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-function-param.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-function-param.result.js
@@ -455,7 +455,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-identifier-math.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-identifier-math.result.js
@@ -274,7 +274,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-inside-parens.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-inside-parens.result.js
@@ -344,7 +344,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-math.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-math.result.js
@@ -398,7 +398,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {
@@ -452,7 +452,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-named-object-method.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-named-object-method.result.js
@@ -188,7 +188,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-object-method-param.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-object-method-param.result.js
@@ -496,7 +496,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await-object-method.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await-object-method.result.js
@@ -350,7 +350,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-await.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-await.result.js
@@ -345,7 +345,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-class-method-named-await.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-class-method-named-await.result.js
@@ -241,7 +241,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-func.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-func.result.js
@@ -127,7 +127,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/async-static-class-method-named-await.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/async-static-class-method-named-await.result.js
@@ -259,7 +259,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/await-identifier-math.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/await-identifier-math.result.js
@@ -256,7 +256,7 @@ module.exports = {
             ]
         },
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/invalid-plain-await.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/invalid-plain-await.result.js
@@ -54,7 +54,7 @@ module.exports = {
     "sourceType": "script",
     "tokens": [
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {

--- a/tests/fixtures/ecma-version/8/not-strict/plain-await.result.js
+++ b/tests/fixtures/ecma-version/8/not-strict/plain-await.result.js
@@ -54,7 +54,7 @@ module.exports = {
     "sourceType": "script",
     "tokens": [
         {
-            "type": "Identifier",
+            "type": "Keyword",
             "value": "await",
             "loc": {
                 "start": {


### PR DESCRIPTION
Previously, `await` tokens were classified as `Identifier`s (see https://github.com/eslint/espree/issues/304). However, this is incorrect; `await` is a keyword similar to `yield`. This fixes the token translator to classify `await` as a keyword.