### PR TITLE
Build: Lock acorn to v4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^4.0.1",
+    "acorn": "4.0.4",
     "acorn-jsx": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See 
 - https://github.com/ternjs/acorn/issues/496
 - https://github.com/ternjs/acorn/issues/497