### PR TITLE
Chore: fix tests for Node 6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ node_js:
     - "0.12"
     - 4
     - 5
+    - 6
+    - 7
 after_success:
     - npm run coveralls

--- a/tests/fixtures/ecma-version/6/regexUFlag/regex-u-extended-escape.result.js
+++ b/tests/fixtures/ecma-version/6/regexUFlag/regex-u-extended-escape.result.js
@@ -1,3 +1,5 @@
+var conditionalRegex = require("../../../../lib/conditional-regex-value");
+
 module.exports = {
     "type": "Program",
     "loc": {
@@ -66,7 +68,7 @@ module.exports = {
                         ],
                         "name": "x"
                     },
-                    "init": {
+                    "init": conditionalRegex({
                         "type": "Literal",
                         "loc": {
                             "start": {
@@ -88,7 +90,7 @@ module.exports = {
                             "pattern": "[\\u{0000000000000061}-\\u{7A}]",
                             "flags": "u"
                         }
-                    }
+                    })
                 }
             ],
             "kind": "var"

--- a/tests/fixtures/ecma-version/6/regexUFlag/regex-u-invalid-extended-escape.result.js
+++ b/tests/fixtures/ecma-version/6/regexUFlag/regex-u-invalid-extended-escape.result.js
@@ -1,6 +1,25 @@
-module.exports = {
-    "index": 12,
-    "lineNumber": 1,
-    "column": 13,
-    "message": "Code point out of bounds"
-};
+function uFlagSupported() {
+    try {
+        RegExp("", "u"); // eslint-disable-line no-invalid-regexp
+        return true;
+    } catch (err) {
+        return false;
+    }
+}
+
+// Acorn's parsing error is different depending on whether the environment supports the regex u flag.
+if (uFlagSupported()) {
+    module.exports = {
+        "index": 9,
+        "lineNumber": 1,
+        "column": 10,
+        "message": "Error parsing regular expression: Invalid regular expression: /\\u{110000}/: Invalid unicode escape"
+    };
+} else {
+    module.exports = {
+        "index": 12,
+        "lineNumber": 1,
+        "column": 13,
+        "message": "Code point out of bounds"
+    };
+}

--- a/tests/fixtures/ecma-version/6/regexUFlag/regex-u-simple.result.js
+++ b/tests/fixtures/ecma-version/6/regexUFlag/regex-u-simple.result.js
@@ -1,3 +1,5 @@
+var conditionalRegex = require("../../../../lib/conditional-regex-value");
+
 module.exports = {
     "type": "Program",
     "loc": {
@@ -66,7 +68,7 @@ module.exports = {
                         ],
                         "name": "foo"
                     },
-                    "init": {
+                    "init": conditionalRegex({
                         "type": "Literal",
                         "loc": {
                             "start": {
@@ -88,7 +90,7 @@ module.exports = {
                             "pattern": "foo",
                             "flags": "u"
                         }
-                    }
+                    })
                 }
             ],
             "kind": "var"

--- a/tests/fixtures/ecma-version/6/regexYFlag/regexp-y-simple.result.js
+++ b/tests/fixtures/ecma-version/6/regexYFlag/regexp-y-simple.result.js
@@ -1,3 +1,5 @@
+var conditionalRegex = require("../../../../lib/conditional-regex-value");
+
 module.exports = {
     "type": "Program",
     "loc": {
@@ -66,7 +68,7 @@ module.exports = {
                         ],
                         "name": "foo"
                     },
-                    "init": {
+                    "init": conditionalRegex({
                         "type": "Literal",
                         "loc": {
                             "start": {
@@ -88,7 +90,7 @@ module.exports = {
                             "pattern": "foo",
                             "flags": "y"
                         }
-                    }
+                    })
                 }
             ],
             "kind": "var"

--- a/tests/lib/conditional-regex-value.js
+++ b/tests/lib/conditional-regex-value.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = function(literalNode) {
+    if (literalNode.regex) {
+        try {
+            literalNode.value = new RegExp(literalNode.regex.pattern, literalNode.regex.flags);
+        } catch (e) {
+            literalNode.value = null;
+        }
+    }
+    return literalNode;
+};

--- a/tests/lib/tester.js
+++ b/tests/lib/tester.js
@@ -58,6 +58,6 @@ module.exports = {
 
         }
 
-        assert.deepEqual(result, expected);
+        assert.deepEqual(result, getRaw(expected));
     }
 };


### PR DESCRIPTION
There are a few issues with the tests causing them to fail with Node 6 and above:

* When parsing regular expression literals with the `y` and `u` flags, espree expected the `value` property of the resulting `Literal` node to `null`. However, since Node 6+ supports these flags, the `value` property was actually a regular expression with the corresponding flags. This commit updates the tests to conditionally expect a regex or `null` depending on whether the flags are supported in the current environment.
* For invalid regular expressions with the `u` flag, Acorn outputs a different error message depending on whether the current environment supports the `u` flag. This commit updates the tests to conditionally expect a particular error message depending on whether the current environment supports the `u` flag.