### PR TITLE
Upgrade: acorn to 5.0.1

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -194,13 +194,6 @@ function esprimaFinishNode(result) {
         }
     }
 
-    // Acorn currently uses expressions instead of declarations in default exports
-    if (result.type === "ExportDefaultDeclaration") {
-        if (/^(Class|Function)Expression$/.test(result.declaration.type)) {
-            result.declaration.type = result.declaration.type.replace("Expression", "Declaration");
-        }
-    }
-
     // Acorn uses undefined instead of null, which affects serialization
     if (result.type === "Literal" && result.value === undefined) {
         result.value = null;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^4.0.11",
+    "acorn": "^5.0.1",
     "acorn-jsx": "^3.0.0"
   },
   "devDependencies": {

--- a/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-class.result.js
+++ b/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-class.result.js
@@ -1,0 +1,244 @@
+module.exports = {
+    "type": "Program",
+    "start": 0,
+    "end": 26,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 26
+        }
+    },
+    "range": [
+        0,
+        26
+    ],
+    "body": [
+        {
+            "type": "ExportDefaultDeclaration",
+            "start": 0,
+            "end": 26,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            },
+            "range": [
+                0,
+                26
+            ],
+            "declaration": {
+                "type": "ClassExpression",
+                "start": 16,
+                "end": 24,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 24
+                    }
+                },
+                "range": [
+                    16,
+                    24
+                ],
+                "id": null,
+                "superClass": null,
+                "body": {
+                    "type": "ClassBody",
+                    "start": 22,
+                    "end": 24,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 22
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 24
+                        }
+                    },
+                    "range": [
+                        22,
+                        24
+                    ],
+                    "body": []
+                }
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "start": 0,
+            "end": 6,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "default",
+            "start": 7,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                7,
+                14
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "start": 16,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                16,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 22,
+            "end": 23,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                22,
+                23
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 23,
+            "end": 24,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                23,
+                24
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 24,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                24,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 25,
+            "end": 26,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            },
+            "range": [
+                25,
+                26
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-class.src.js
+++ b/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-class.src.js
@@ -1,0 +1,1 @@
+export default (class {});

--- a/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-function.result.js
+++ b/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-function.result.js
@@ -1,0 +1,286 @@
+module.exports = {
+    "type": "Program",
+    "start": 0,
+    "end": 30,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 30
+        }
+    },
+    "range": [
+        0,
+        30
+    ],
+    "body": [
+        {
+            "type": "ExportDefaultDeclaration",
+            "start": 0,
+            "end": 30,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                0,
+                30
+            ],
+            "declaration": {
+                "type": "FunctionExpression",
+                "start": 16,
+                "end": 28,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 28
+                    }
+                },
+                "range": [
+                    16,
+                    28
+                ],
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "params": [],
+                "body": {
+                    "type": "BlockStatement",
+                    "start": 26,
+                    "end": 28,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 28
+                        }
+                    },
+                    "range": [
+                        26,
+                        28
+                    ],
+                    "body": []
+                }
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "start": 0,
+            "end": 6,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "default",
+            "start": 7,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                7,
+                14
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 16,
+            "end": 24,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                16,
+                24
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 24,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                24,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 25,
+            "end": 26,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 26
+                }
+            },
+            "range": [
+                25,
+                26
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 26,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 27,
+            "end": 28,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                27,
+                28
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 28,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "start": 29,
+            "end": 30,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                29,
+                30
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-function.src.js
+++ b/tests/fixtures/ecma-version/6/modules/export-default-parenthesized-function.src.js
@@ -1,0 +1,1 @@
+export default (function(){});

--- a/tests/fixtures/ecma-version/8/modules/export-default-async-expression.result.js
+++ b/tests/fixtures/ecma-version/8/modules/export-default-async-expression.result.js
@@ -32,7 +32,7 @@ module.exports = {
                 38
             ],
             "declaration": {
-                "type": "FunctionDeclaration",
+                "type": "FunctionExpression",
                 "loc": {
                     "start": {
                         "line": 1,


### PR DESCRIPTION
> ### Bug fixes
> Raise an error for duplicated lexical bindings.
> Fix spurious error when an assignement expression occurred after a spread expression.
> Accept regular expressions after `of` (in `for`/`of`), `yield` (in a generator), and braced arrow functions.
> Allow labels in front or `var` declarations, even in strict mode.
> ### Breaking changes
> Parse declarations following `export default` as declaration nodes, not expressions. This means that class and function declarations nodes can now have `null` as their `id`.