### PR TITLE
Upgrade: eslint to 2.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "browserify": "^7.0.0",
     "chai": "^1.10.0",
-    "eslint": "^2.0.0-beta.1",
+    "eslint": "^2.13.1",
     "eslint-config-eslint": "^3.0.0",
     "eslint-release": "^0.10.0",
     "esprima": "latest",


### PR DESCRIPTION
This upgrades our `eslint` devDependency to the latest version that we can support while still supporting Node < 4. Previously, we were using `2.0.0-beta1`.