### PR TITLE
Fix: add AwaitExpression to espree.Syntax (fixes #331)

### DIFF
--- a/lib/ast-node-types.js
+++ b/lib/ast-node-types.js
@@ -21,6 +21,7 @@ module.exports = {
     ArrayExpression: "ArrayExpression",
     ArrayPattern: "ArrayPattern",
     ArrowFunctionExpression: "ArrowFunctionExpression",
+    AwaitExpression: "AwaitExpression",
     BlockStatement: "BlockStatement",
     BinaryExpression: "BinaryExpression",
     BreakStatement: "BreakStatement",


### PR DESCRIPTION
This adds `AwaitExpression` to `espree.Syntax`. It looks like this wasn't added when we started supporting async functions.