### PR TITLE
Update: add initial support for ES2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ var ast = espree.parse(code, {
     // create a top-level tokens array containing all tokens
     tokens: false,
 
-    // Set to 3, 5, 6, 7, or 8 to specify the version of ECMAScript syntax you want to use.
-    // You can also set to 2015 (same as 6), 2016 (same as 7), or 2017 (same as 8) to use the year-based naming.
+    // Set to 3, 5 (default), 6, 7, 8, or 9 to specify the version of ECMAScript syntax you want to use.
+    // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), or 2018 (same as 9) to use the year-based naming.
     ecmaVersion: 5,
 
     // specify which type of script you're parsing ("script" or "module")
@@ -138,14 +138,17 @@ All of them.
 
 ### What ECMAScript 7/2016 features do you support?
 
-There is only one ECMAScript 7 syntax change: the exponentiation operator. Espree supports this.
+There is only one ECMAScript 2016 syntax change: the exponentiation operator. Espree supports this.
 
 ### What ECMAScript 2017 features do you support?
 
-Because ECMAScript 2017 is still under development, we are implementing features as they are finalized. Currently, Espree supports:
+There are two ECMAScript 2017 syntax changes: `async` functions, and trailing commas in function declarations and calls. Espree supports both of them.
 
-* `async` functions
-* Trailing commas in function declarations and calls (including arrow functions and concise methods)
+### What ECMAScript 2018 features do you support?
+
+Because ECMAScript 2018 is still under development, we are implementing features as they are finalized. Currently, Espree supports:
+
+* Invalid escape sequences in tagged template literals
 
 ### How do you determine which experimental features to support?
 

--- a/espree.js
+++ b/espree.js
@@ -142,6 +142,7 @@ function normalizeEcmaVersion(ecmaVersion) {
             case 6:
             case 7:
             case 8:
+            case 9:
                 return version;
 
             default:

--- a/lib/token-translator.js
+++ b/lib/token-translator.js
@@ -230,7 +230,7 @@ TokenTranslator.prototype = {
             // store new curly for later
             this._curlyBrace = token;
             return;
-        } else if (token.type === tt.template) {
+        } else if (token.type === tt.template || token.type === tt.invalidTemplate) {
             if (this._curlyBrace) {
                 templateTokens.push(this._curlyBrace);
                 this._curlyBrace = null;

--- a/tests/fixtures/ecma-version/9/malformed-template-literal-escape.result.js
+++ b/tests/fixtures/ecma-version/9/malformed-template-literal-escape.result.js
@@ -1,0 +1,152 @@
+module.exports = {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 13
+        }
+    },
+    "range": [
+        0,
+        13
+    ],
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                0,
+                13
+            ],
+            "expression": {
+                "type": "TaggedTemplateExpression",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 13
+                    }
+                },
+                "range": [
+                    0,
+                    13
+                ],
+                "tag": {
+                    "type": "Identifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 3
+                        }
+                    },
+                    "range": [
+                        0,
+                        3
+                    ],
+                    "name": "foo"
+                },
+                "quasi": {
+                    "type": "TemplateLiteral",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 3
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 13
+                        }
+                    },
+                    "range": [
+                        3,
+                        13
+                    ],
+                    "expressions": [],
+                    "quasis": [
+                        {
+                            "type": "TemplateElement",
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 13
+                                }
+                            },
+                            "range": [
+                                3,
+                                13
+                            ],
+                            "value": {
+                                "raw": "\\unicode",
+                                "cooked": null
+                            },
+                            "tail": true
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                3
+            ]
+        },
+        {
+            "type": "Template",
+            "value": "`\\unicode`",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 3
+                },
+                "end": {
+                    "line": 1,
+                    "column": 13
+                }
+            },
+            "range": [
+                3,
+                13
+            ]
+        }
+    ]
+}

--- a/tests/fixtures/ecma-version/9/malformed-template-literal-escape.src.js
+++ b/tests/fixtures/ecma-version/9/malformed-template-literal-escape.src.js
@@ -1,0 +1,1 @@
+foo`\unicode`


### PR DESCRIPTION
~~(Builds on #347, look at that first)~~

This adds support for `ecmaVersion: 2018` (or `ecmaVersion: 9`). Currently, the only stage 4 proposal in ES2018 is the [template literal revision](https://github.com/tc39/proposal-template-literal-revision), which Acorn now supports in 5.1.0.