### PR TITLE
Fix: Remove blockBindings from docs (fixes #307, fixes #339)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Espree is licensed under a permissive BSD 2-clause license.
 
 * The `tokenize()` method does not use `ecmaFeatures`. Any string will be tokenized completely based on ECMAScript 6 semantics.
 * Trailing whitespace no longer is counted as part of a node.
-* `let` and `const` declarations are no longer parsed by default. You must opt-in using `ecmaFeatures.blockBindings`.
 * The `esparse` and `esvalidate` binary scripts have been removed.
 * There is no `tolerant` option. We will investigate adding this back in the future.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Espree is licensed under a permissive BSD 2-clause license.
 
 * The `tokenize()` method does not use `ecmaFeatures`. Any string will be tokenized completely based on ECMAScript 6 semantics.
 * Trailing whitespace no longer is counted as part of a node.
+* `let` and `const` declarations are no longer parsed by default. You must opt-in by using an `ecmaVersion` newer than `5` or setting `sourceType` to `module`.
 * The `esparse` and `esvalidate` binary scripts have been removed.
 * There is no `tolerant` option. We will investigate adding this back in the future.
 


### PR DESCRIPTION
This PR removes the mentioning of the `blockBindings` option from the *Differences from Espree 2.x* section in the README as it is no longer supported and the opt-in apparently not necessary anymore.

> ~let and const declarations are no longer parsed by default. You must opt-in using ecmaFeatures.blockBindings.~