### PR TITLE
Chore: add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
This PR adds `.npmrc` to not generate `package-lock.json` by npm. This is the same as `eslint/eslint` repo.