### PR TITLE
WIP: Upgrade: acorn to ^5.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^5.2.1",
+    "acorn": "^5.3.0",
     "acorn-jsx": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pulls in a bugfix to ensure for-of statements are interpreted as assignment expressions.