### PR TITLE
Upgrade: acorn v5.3.0

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -318,7 +318,7 @@ acorn.plugins.espree = function(instance) {
 
     instance.extend("toAssignable", function(toAssignable) {
 
-        return /** @this acorn.Parser */ function(node, isBinding) {
+        return /** @this acorn.Parser */ function(node, isBinding, refDestructuringErrors) {
 
             if (extra.ecmaFeatures.experimentalObjectRestSpread &&
                     node.type === "ObjectExpression"
@@ -339,7 +339,7 @@ acorn.plugins.espree = function(instance) {
 
                 return node;
             } else {
-                return toAssignable.call(this, node, isBinding);
+                return toAssignable.call(this, node, isBinding, refDestructuringErrors);
             }
         };
 
@@ -393,14 +393,15 @@ acorn.plugins.espree = function(instance) {
          * Override `checkPropClash` method to avoid clash on rest/spread properties.
          * @param {ASTNode} prop A property node to check.
          * @param {Object} propHash Names map.
+         * @param {Object} refDestructuringErrors Destructuring error information.
          * @returns {void}
          * @this acorn.Parser
          */
-        return function(prop, propHash) {
+        return function(prop, propHash, refDestructuringErrors) {
             if (prop.type === "ExperimentalRestProperty" || prop.type === "ExperimentalSpreadProperty") {
                 return;
             }
-            checkPropClash.call(this, prop, propHash);
+            checkPropClash.call(this, prop, propHash, refDestructuringErrors);
         };
     });
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^5.2.1",
+    "acorn": "^5.3.0",
     "acorn-jsx": "^3.0.0"
   },
   "devDependencies": {

--- a/tests/fixtures/ecma-version/6/modules/invalid-await.result.js
+++ b/tests/fixtures/ecma-version/6/modules/invalid-await.result.js
@@ -2,5 +2,5 @@ module.exports = {
     "index": 11,
     "lineNumber": 1,
     "column": 12,
-    "message": "The keyword 'await' is reserved"
+    "message": "Can not use keyword 'await' outside an async function"
 };

--- a/tests/fixtures/ecma-version/8/modules/async-func.result.js
+++ b/tests/fixtures/ecma-version/8/modules/async-func.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 8,
     "index": 7,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/await-identifier-math.result.js
+++ b/tests/fixtures/ecma-version/8/modules/await-identifier-math.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 18,
     "index": 17,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-arrow-param-parens.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-arrow-param-parens.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 8,
     "index": 7,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-arrow-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-arrow-param.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 7,
     "index": 6,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-destructured-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-destructured-param.result.js
@@ -2,5 +2,5 @@ module.exports = {
     "index": 8,
     "lineNumber": 1,
     "column": 9,
-    "message": "The keyword 'await' is reserved"
-}
+    "message": "Can not use keyword 'await' outside an async function"
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-named-destructured-array-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-named-destructured-array-param.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 9,
     "index": 8,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-named-destructured-param.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-named-destructured-param.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 12,
     "index": 11,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-await-top-level.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-await-top-level.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 1,
     "index": 0,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/invalid-plain-await.result.js
+++ b/tests/fixtures/ecma-version/8/modules/invalid-plain-await.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 1,
     "index": 0,
     "lineNumber": 1
-}
+};

--- a/tests/fixtures/ecma-version/8/modules/plain-await.result.js
+++ b/tests/fixtures/ecma-version/8/modules/plain-await.result.js
@@ -1,6 +1,6 @@
 module.exports = {
-    "message": "The keyword 'await' is reserved",
+    "message": "Can not use keyword 'await' outside an async function",
     "column": 1,
     "index": 0,
     "lineNumber": 1
-}
+};


### PR DESCRIPTION
This PR fixes some test failures that acorn v5.3.0 introduced.

- It added a new argument to some methods we are overriding: `toAssignable` and `checkPropClash`. It didn't seem to trigger crashes but caused to overlook some syntax errors.
- It improved the error message around `async`/`await`.