### PR TITLE
Chore: Adding .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.js text eol=lf


### PR DESCRIPTION
Keeping it simple for now. Please clone the branch locally and test.

Note that 17 tests will fail because `acorn@^5.2.1` pulls in 5.3.0, fixed by #365. I'll rebase once that gets merged.