### PR TITLE
Upgrade: acorn 5.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^5.5.0",
+    "acorn": "^5.5.1",
     "acorn-jsx": "^3.0.0"
   },
   "devDependencies": {

--- a/tests/fixtures/ecma-version/6/templateStrings/octal-literal.result.js
+++ b/tests/fixtures/ecma-version/6/templateStrings/octal-literal.result.js
@@ -2,5 +2,5 @@ module.exports = {
     "index": 1,
     "lineNumber": 1,
     "column": 2,
-    "message": "Octal literal in strict mode"
+    "message": "Octal literal in template string"
 };


### PR DESCRIPTION
acorn 5.5.1 changed an error message (see acornjs/acorn#678). This PR fixes the tests to expect the new message.