### PR TITLE
Build: Adding rc release script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "gh-release": "eslint-gh-release",
     "alpharelease": "eslint-prerelease alpha",
     "betarelease": "eslint-prerelease beta",
+    "rcrelease": "eslint-prerelease rc",
     "browserify": "node Makefile.js browserify"
   }
 }


### PR DESCRIPTION
Looking at the eslint-release code, it *looks* like we should be able to do an rc release of espree by supplying the rc prerelease label to the eslint-prerelease script. So I created a "rcrelease" script here to do just that.