### PR TITLE
Upgrade: eslint-release@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 npm-debug.log
 _test.js
 .idea
+.eslint-release-info.json

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "chai": "^1.10.0",
     "eslint": "^2.13.1",
     "eslint-config-eslint": "^3.0.0",
-    "eslint-release": "^0.11.1",
+    "eslint-release": "^1.0.0",
     "esprima": "latest",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",
     "istanbul": "~0.2.6",
@@ -51,12 +51,11 @@
     "generate-regex": "node tools/generate-identifier-regex.js",
     "test": "npm run-script lint && node Makefile.js test",
     "lint": "node Makefile.js lint",
-    "release": "eslint-release",
-    "ci-release": "eslint-ci-release",
-    "gh-release": "eslint-gh-release",
-    "alpharelease": "eslint-prerelease alpha",
-    "betarelease": "eslint-prerelease beta",
-    "rcrelease": "eslint-prerelease rc",
-    "browserify": "node Makefile.js browserify"
+    "browserify": "node Makefile.js browserify",
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "publish-release": "eslint-publish-release"
   }
 }


### PR DESCRIPTION
(refs https://github.com/eslint/eslint/issues/10631)

This updates `eslint-release` to allow the package to still be published from the Jenkins server now that we have 2FA enabled on the bot account.

Some changes are also needed on the Jenkins server -- I plan to make those changes after this is merged.