### PR TITLE
Pass the sourceFile parser option through to acorn

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -99,6 +99,7 @@ module.exports = () => Parser => class Espree extends Parser {
             sourceType: isModule ? "module" : "script",
             ranges: options.range === true,
             locations: options.loc === true,
+            sourceFile: options.sourceFile,
 
             // Truthy value is true for backward compatibility.
             allowReturnOutsideFunction: Boolean(ecmaFeatures.globalReturn),

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -81,5 +81,14 @@ describe("parse()", () => {
             espree.parse("foo", Object.freeze({ ecmaFeatures: Object.freeze({}) }));
         });
 
+        it("should pass sourceFile through", () => {
+            const ast = espree.parse("var foo = bar;", {
+                loc: true,
+                sourceFile: "the/source.js"
+            });
+
+            assert.strictEqual(ast.loc.source, "the/source.js");
+        });
+
     });
 });


### PR DESCRIPTION
I'd like to use espree in a project that has to generate source maps, and for that I need the `loc` objects to include the url/file name of the source. Luckily `acorn` already supports this feature, so it's just a matter of letting the `sourceFile` parser option through.

Esprima calls this option `source` so it might be worth it to mitigate that difference as well.