### PR TITLE
Breaking: validate parser options (fixes #384)

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -63,7 +63,7 @@ function normalizeSourceType(sourceType = "script") {
  * @throws {Error} throw an error if found invalid option.
  * @returns {Object} normalized options
  */
-function validate(options) {
+function normalizeOptions(options) {
     const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
     const sourceType = normalizeSourceType(options.sourceType);
 
@@ -114,7 +114,7 @@ module.exports = () => Parser => class Espree extends Parser {
         if (typeof code !== "string" && !(code instanceof String)) {
             code = String(code);
         }
-        const options = validate(opts);
+        const options = normalizeOptions(opts);
 
         const ecmaFeatures = options.ecmaFeatures || {};
         const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -10,12 +10,14 @@ const STATE = Symbol("espree's internal state");
 const ESPRIMA_FINISH_NODE = Symbol("espree's esprimaFinishNode");
 const tokTypes = Object.assign({}, acorn.tokTypes, jsx.tokTypes);
 
+
 /**
  * Normalize ECMAScript version from the initial config
  * @param {number} ecmaVersion ECMAScript version from the initial config
+ * @throws {Error} throws an error if the ecmaVersion is invalid.
  * @returns {number} normalized ECMAScript version
  */
-function normalizeEcmaVersion(ecmaVersion) {
+function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
     if (typeof ecmaVersion === "number") {
         let version = ecmaVersion;
 
@@ -36,11 +38,39 @@ function normalizeEcmaVersion(ecmaVersion) {
                 return version;
 
             default:
-                throw new Error("Invalid ecmaVersion.");
         }
-    } else {
-        return DEFAULT_ECMA_VERSION;
     }
+
+    throw new Error("Invalid ecmaVersion.");
+}
+
+/**
+ * Normalize sourceType from the initial config
+ * @param {string} sourceType to normalize
+ * @throws {Error} throw an error if sourceType is invalid
+ * @returns {string} normalized sourceType
+ */
+function normalizeSourceType(sourceType = "script") {
+    if (sourceType === "script" || sourceType === "module") {
+        return sourceType;
+    }
+    throw new Error("Invalid sourceType.");
+}
+
+/**
+ * Normalize parserOptions
+ * @param {Object} options the parser options to normalize
+ * @throws {Error} throw an error if found invalid option.
+ * @returns {Object} normalized options
+ */
+function validate(options) {
+    const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
+    const sourceType = normalizeSourceType(options.sourceType);
+
+    if (sourceType === "module" && ecmaVersion < 6) {
+        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6!");
+    }
+    return Object.assign({}, options, { ecmaVersion, sourceType });
 }
 
 /**
@@ -77,17 +107,17 @@ function convertAcornCommentToEsprimaComment(block, text, start, end, startLoc, 
 }
 
 module.exports = () => Parser => class Espree extends Parser {
-    constructor(options, code) {
-        if (typeof options !== "object" || options === null) {
-            options = {};
+    constructor(opts, code) {
+        if (typeof opts !== "object" || opts === null) {
+            opts = {};
         }
         if (typeof code !== "string" && !(code instanceof String)) {
             code = String(code);
         }
+        const options = validate(opts);
 
         const ecmaFeatures = options.ecmaFeatures || {};
         const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
-        const isModule = options.sourceType === "module";
         const tokenTranslator =
             options.tokens === true
                 ? new TokenTranslator(tokTypes, code)
@@ -95,8 +125,8 @@ module.exports = () => Parser => class Espree extends Parser {
 
         // Initialize acorn parser.
         super({
-            ecmaVersion: isModule ? Math.max(6, ecmaVersion) : ecmaVersion,
-            sourceType: isModule ? "module" : "script",
+            ecmaVersion,
+            sourceType: options.sourceType,
             ranges: options.range === true,
             locations: options.loc === true,
 

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -66,11 +66,13 @@ function normalizeSourceType(sourceType = "script") {
 function normalizeOptions(options) {
     const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
     const sourceType = normalizeSourceType(options.sourceType);
+    const ranges = options.range === true;
+    const locations = options.loc === true;
 
     if (sourceType === "module" && ecmaVersion < 6) {
-        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6");
+        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6.");
     }
-    return Object.assign({}, options, { ecmaVersion, sourceType });
+    return Object.assign({}, options, { ecmaVersion, sourceType, ranges, locations });
 }
 
 /**
@@ -114,10 +116,9 @@ module.exports = () => Parser => class Espree extends Parser {
         if (typeof code !== "string" && !(code instanceof String)) {
             code = String(code);
         }
-        const options = normalizeOptions(opts);
 
+        const options = normalizeOptions(opts);
         const ecmaFeatures = options.ecmaFeatures || {};
-        const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
         const tokenTranslator =
             options.tokens === true
                 ? new TokenTranslator(tokTypes, code)
@@ -125,10 +126,12 @@ module.exports = () => Parser => class Espree extends Parser {
 
         // Initialize acorn parser.
         super({
-            ecmaVersion,
+
+            // TODO: use {...options} when spread is supported(Node.js >= 8.3.0).
+            ecmaVersion: options.ecmaVersion,
             sourceType: options.sourceType,
-            ranges: options.range === true,
-            locations: options.loc === true,
+            ranges: options.ranges,
+            locations: options.locations,
 
             // Truthy value is true for backward compatibility.
             allowReturnOutsideFunction: Boolean(ecmaFeatures.globalReturn),

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -37,7 +37,7 @@ function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
             case 10:
                 return version;
 
-            default:
+            // no default
         }
     }
 

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -70,7 +70,7 @@ function normalizeOptions(options) {
     const locations = options.loc === true;
 
     if (sourceType === "module" && ecmaVersion < 6) {
-        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6.");
+        throw new Error("sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.");
     }
     return Object.assign({}, options, { ecmaVersion, sourceType, ranges, locations });
 }

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -68,7 +68,7 @@ function normalizeOptions(options) {
     const sourceType = normalizeSourceType(options.sourceType);
 
     if (sourceType === "module" && ecmaVersion < 6) {
-        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6!");
+        throw new Error("sourceType 'module' is not supported when ecmaVersion < 6");
     }
     return Object.assign({}, options, { ecmaVersion, sourceType });
 }

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -141,6 +141,30 @@ describe("ecmaVersion", () => {
             }, /Invalid ecmaVersion/);
         });
 
+        it("Should throw error using invalid year", () => {
+            assert.throws(() => {
+                espree.parse(
+                    "let foo = bar;", {
+                        ecmaVersion: "2015",
+                        comment: true,
+                        tokens: true,
+                        range: true,
+                        loc: true
+                    }
+                );
+            }, /Invalid ecmaVersion/);
+        });
+
+        it("Should throw error when using module in pre-ES6", () => {
+            assert.throws(() => {
+                espree.parse(
+                    "let foo = bar;", {
+                        ecmaVersion: 5,
+                        sourceType: "module"
+                    }
+                );
+            }, /sourceType 'module' is not supported when ecmaVersion < 6!/);
+        });
     });
 
 });

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -163,7 +163,7 @@ describe("ecmaVersion", () => {
                         sourceType: "module"
                     }
                 );
-            }, /sourceType 'module' is not supported when ecmaVersion < 6/);
+            }, /sourceType 'module' is not supported when ecmaVersion < 2015/);
         });
     });
 

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -141,7 +141,7 @@ describe("ecmaVersion", () => {
             }, /Invalid ecmaVersion/);
         });
 
-        it("Should throw error using invalid year", () => {
+        it("Should throw error when non-numeric year is provided", () => {
             assert.throws(() => {
                 espree.parse(
                     "let foo = bar;", {

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -163,7 +163,7 @@ describe("ecmaVersion", () => {
                         sourceType: "module"
                     }
                 );
-            }, /sourceType 'module' is not supported when ecmaVersion < 6!/);
+            }, /sourceType 'module' is not supported when ecmaVersion < 6/);
         });
     });
 

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -24,7 +24,7 @@ describe("parse()", () => {
         it("should have correct column number when strict mode error occurs", () => {
 
             try {
-                espree.parse("function fn(a, a) {\n}", { sourceType: "module" });
+                espree.parse("function fn(a, a) {\n}", { ecmaVersion: 6, sourceType: "module" });
             } catch (err) {
                 assert.strictEqual(err.column, 16);
             }


### PR DESCRIPTION
it will throw an error if any of the conditions is true:

+ ecmaVersion is invalid
+ sourceType is invalid
+ ecmaVersion < 6 & sourceType: "module"

is there some more conditions need to be covered?