### PR TITLE
Fix: tokenize the latest right curly brace (fixes #403)

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -175,6 +175,9 @@ module.exports = () => Parser => class Espree extends Parser {
             this.next();
         } while (this.type !== tokTypes.eof);
 
+        // Consume the final eof token
+        this.next();
+
         const extra = this[STATE];
         const tokens = extra.tokens;
 

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -199,6 +199,10 @@ describe("tokenize()", () => {
         espree.tokenize("foo", Object.freeze({ ecmaFeatures: Object.freeze({}) }));
     });
 
+    /**
+     * Make sure we tokenize closing curly brace in a block statement at end of file
+     * @see https://github.com/eslint/espree/issues/403 for more information
+     */
     it("should produce tokens when } is the last token", () => {
         const tokens = espree.tokenize("{}");
 

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -199,4 +199,16 @@ describe("tokenize()", () => {
         espree.tokenize("foo", Object.freeze({ ecmaFeatures: Object.freeze({}) }));
     });
 
+    it("should produce tokens when } is the last token", () => {
+        const tokens = espree.tokenize("{}");
+
+        assert.deepStrictEqual(
+            tester.getRaw(tokens),
+            [
+                { type: "Punctuator", value: "{" },
+                { type: "Punctuator", value: "}" }
+            ]
+        );
+    });
+
 });


### PR DESCRIPTION
There is a logic in `TokenTranslator::onToken` about the latest curly brace
https://github.com/eslint/espree/blob/6ebc21947166399a0b4918d4a1beb9d610650336/lib/token-translator.js#L196-L204
But it executes only at first `eof` token (it seems strange that the first token is `eof`, but it comes from Acorn's init state)
I've added a call of `next` for the `TokenTranslator::onToken` to be executed with the last `eof` token

And I've noticed two failed tests, but they've already fixed at #416 