### PR TITLE
Update: improve error messaging when validating ecmaVersion

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -18,8 +18,10 @@ const tokTypes = Object.assign({}, acorn.tokTypes, jsx.tokTypes);
  * @returns {number} normalized ECMAScript version
  */
 function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
-    if (typeof ecmaVersion !== "number") {
-        throw new Error("ecmaVersion must be a number.");
+    const ecmaVersionType = typeof ecmaVersion;
+
+    if (ecmaVersionType !== "number") {
+        throw new Error(`ecmaVersion must be a number. Received value of type ${ecmaVersionType} instead.`);
     }
 
     let version = ecmaVersion;

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -18,10 +18,8 @@ const tokTypes = Object.assign({}, acorn.tokTypes, jsx.tokTypes);
  * @returns {number} normalized ECMAScript version
  */
 function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
-    const ecmaVersionType = typeof ecmaVersion;
-
-    if (ecmaVersionType !== "number") {
-        throw new Error(`ecmaVersion must be a number. Received value of type ${ecmaVersionType} instead.`);
+    if (typeof ecmaVersion !== "number") {
+        throw new Error(`ecmaVersion must be a number. Received value of type ${typeof ecmaVersion} instead.`);
     }
 
     let version = ecmaVersion;

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -18,28 +18,30 @@ const tokTypes = Object.assign({}, acorn.tokTypes, jsx.tokTypes);
  * @returns {number} normalized ECMAScript version
  */
 function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
-    if (typeof ecmaVersion === "number") {
-        let version = ecmaVersion;
+    if (typeof ecmaVersion !== "number") {
+        throw new Error("ecmaVersion must be a number.");
+    }
 
-        // Calculate ECMAScript edition number from official year version starting with
-        // ES2015, which corresponds with ES6 (or a difference of 2009).
-        if (version >= 2015) {
-            version -= 2009;
-        }
+    let version = ecmaVersion;
 
-        switch (version) {
-            case 3:
-            case 5:
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-            case 11:
-                return version;
+    // Calculate ECMAScript edition number from official year version starting with
+    // ES2015, which corresponds with ES6 (or a difference of 2009).
+    if (version >= 2015) {
+        version -= 2009;
+    }
 
-            // no default
-        }
+    switch (version) {
+        case 3:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+            return version;
+
+        // no default
     }
 
     throw new Error("Invalid ecmaVersion.");

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -152,7 +152,7 @@ describe("ecmaVersion", () => {
                         loc: true
                     }
                 );
-            }, /Invalid ecmaVersion/);
+            }, /ecmaVersion must be a number/);
         });
 
         it("Should throw error when using module in pre-ES6", () => {

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -152,7 +152,7 @@ describe("ecmaVersion", () => {
                         loc: true
                     }
                 );
-            }, /ecmaVersion must be a number/);
+            }, /ecmaVersion must be a number. Received value of type string instead/);
         });
 
         it("Should throw error when using module in pre-ES6", () => {


### PR DESCRIPTION
Inspired by https://github.com/eslint/eslint/issues/12101. This PR enhances the error messaging when validating `ecmaVersion` to distinguish between when the the value provided is the incorrect data type versus when it's not a valid numeric value.

I labeled this an enhancement since it's not technically a bug fix, but please let me know if you disagree!