### PR TITLE
Docs: update readme to mention ES2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const ast = espree.parse(code, {
     tokens: false,
 
     // Set to 3, 5 (default), 6, 7, 8, 9, or 10 to specify the version of ECMAScript syntax you want to use.
-    // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), or 2019 (same as 10) to use the year-based naming.
+    // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), or 2020 (same as 11) to use the year-based naming.
     ecmaVersion: 5,
 
     // specify which type of script you're parsing ("script" or "module")


### PR DESCRIPTION
Updating the readme to document the new `ecmaVersion: 2020` option introduced in  https://github.com/eslint/espree/commit/f5e58cc5e9030793baca3426366b8d7286ef5b89.