### PR TITLE
Breaking: drop Node v8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: node_js
 node_js:
-    - 6
-    - 7
-    - 8
-    - 9
     - 10
-    - 11
     - 12
+    - 13
 
 script:
-    - if [ $TRAVIS_NODE_VERSION -ge 8 ]; then node Makefile.js lint; fi
+    - node Makefile.js lint
     - node Makefile.js test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+    - "10.12.0"
     - 10
     - 12
     - 13

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "espree.js"
   ],
   "engines": {
-    "node": ">=6.0.0"
+    "node": "^10.12.0 || >=12.0.0"
   },
   "repository": "eslint/espree",
   "bugs": {


### PR DESCRIPTION
Now that Node v8 is no longer being supported (and we're dropping support in ESLint core), it seems prudent to also drop support in Espree.

Questions:
Have I missed anything?