### PR TITLE
Update: add latestEcmaVersion & supportedEcmaVersions

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -172,6 +172,6 @@ exports.VisitorKeys = (function() {
     return require("eslint-visitor-keys").KEYS;
 }());
 
-exports.getLatestEcmaVersion = getLatestEcmaVersion;
+exports.latestEcmaVersion = getLatestEcmaVersion();
 
-exports.getSupportedEcmaVersions = getSupportedEcmaVersions;
+exports.supportedEcmaVersions = getSupportedEcmaVersions();

--- a/espree.js
+++ b/espree.js
@@ -62,6 +62,7 @@ const acorn = require("acorn");
 const jsx = require("acorn-jsx");
 const astNodeTypes = require("./lib/ast-node-types");
 const espree = require("./lib/espree");
+const { latestEcmaVersion, supportedEcmaVersions } = require("./lib/options");
 
 // To initialize lazily.
 const parsers = {
@@ -170,3 +171,7 @@ exports.Syntax = (function() {
 exports.VisitorKeys = (function() {
     return require("eslint-visitor-keys").KEYS;
 }());
+
+exports.latestEcmaVersion = latestEcmaVersion;
+
+exports.supportedEcmaVersions = supportedEcmaVersions;

--- a/espree.js
+++ b/espree.js
@@ -62,7 +62,7 @@ const acorn = require("acorn");
 const jsx = require("acorn-jsx");
 const astNodeTypes = require("./lib/ast-node-types");
 const espree = require("./lib/espree");
-const { latestEcmaVersion, supportedEcmaVersions } = require("./lib/options");
+const { getLatestEcmaVersion, getSupportedEcmaVersions } = require("./lib/options");
 
 // To initialize lazily.
 const parsers = {
@@ -172,6 +172,6 @@ exports.VisitorKeys = (function() {
     return require("eslint-visitor-keys").KEYS;
 }());
 
-exports.latestEcmaVersion = latestEcmaVersion;
+exports.getLatestEcmaVersion = getLatestEcmaVersion;
 
-exports.supportedEcmaVersions = supportedEcmaVersions;
+exports.getSupportedEcmaVersions = getSupportedEcmaVersions;

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -2,77 +2,11 @@
 
 /* eslint-disable no-param-reassign*/
 const TokenTranslator = require("./token-translator");
+const { normalizeOptions } = require("./options");
 
-const DEFAULT_ECMA_VERSION = 5;
 const STATE = Symbol("espree's internal state");
 const ESPRIMA_FINISH_NODE = Symbol("espree's esprimaFinishNode");
 
-/**
- * Normalize ECMAScript version from the initial config
- * @param {number} ecmaVersion ECMAScript version from the initial config
- * @throws {Error} throws an error if the ecmaVersion is invalid.
- * @returns {number} normalized ECMAScript version
- */
-function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
-    if (typeof ecmaVersion !== "number") {
-        throw new Error(`ecmaVersion must be a number. Received value of type ${typeof ecmaVersion} instead.`);
-    }
-
-    let version = ecmaVersion;
-
-    // Calculate ECMAScript edition number from official year version starting with
-    // ES2015, which corresponds with ES6 (or a difference of 2009).
-    if (version >= 2015) {
-        version -= 2009;
-    }
-
-    switch (version) {
-        case 3:
-        case 5:
-        case 6:
-        case 7:
-        case 8:
-        case 9:
-        case 10:
-        case 11:
-            return version;
-
-        // no default
-    }
-
-    throw new Error("Invalid ecmaVersion.");
-}
-
-/**
- * Normalize sourceType from the initial config
- * @param {string} sourceType to normalize
- * @throws {Error} throw an error if sourceType is invalid
- * @returns {string} normalized sourceType
- */
-function normalizeSourceType(sourceType = "script") {
-    if (sourceType === "script" || sourceType === "module") {
-        return sourceType;
-    }
-    throw new Error("Invalid sourceType.");
-}
-
-/**
- * Normalize parserOptions
- * @param {Object} options the parser options to normalize
- * @throws {Error} throw an error if found invalid option.
- * @returns {Object} normalized options
- */
-function normalizeOptions(options) {
-    const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
-    const sourceType = normalizeSourceType(options.sourceType);
-    const ranges = options.range === true;
-    const locations = options.loc === true;
-
-    if (sourceType === "module" && ecmaVersion < 6) {
-        throw new Error("sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.");
-    }
-    return Object.assign({}, options, { ecmaVersion, sourceType, ranges, locations });
-}
 
 /**
  * Converts an Acorn comment to a Esprima comment.

--- a/lib/options.js
+++ b/lib/options.js
@@ -82,15 +82,15 @@ function normalizeOptions(options) {
  * Get the latest ECMAScript version supported by Espree.
  * @returns {number} The latest ECMAScript version.
  */
-function latestEcmaVersion() {
-    return Math.max(...SUPPORTED_VERSIONS);
+function getLatestEcmaVersion() {
+    return SUPPORTED_VERSIONS[SUPPORTED_VERSIONS.length - 1];
 }
 
 /**
  * Get the list of ECMAScript versions supported by Espree.
  * @returns {number[]} An array containing the supported ECMAScript versions.
  */
-function supportedEcmaVersions() {
+function getSupportedEcmaVersions() {
     return [...SUPPORTED_VERSIONS];
 }
 
@@ -100,6 +100,6 @@ function supportedEcmaVersions() {
 
 module.exports = {
     normalizeOptions,
-    latestEcmaVersion,
-    supportedEcmaVersions
+    getLatestEcmaVersion,
+    getSupportedEcmaVersions
 };

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview A collection of methods for processing Espree's options.
+ * @author Kai Cataldo
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const DEFAULT_ECMA_VERSION = 5;
+const SUPPORTED_VERSIONS = [
+    3,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11
+];
+
+/**
+ * Normalize ECMAScript version from the initial config
+ * @param {number} ecmaVersion ECMAScript version from the initial config
+ * @throws {Error} throws an error if the ecmaVersion is invalid.
+ * @returns {number} normalized ECMAScript version
+ */
+function normalizeEcmaVersion(ecmaVersion = DEFAULT_ECMA_VERSION) {
+    if (typeof ecmaVersion !== "number") {
+        throw new Error(`ecmaVersion must be a number. Received value of type ${typeof ecmaVersion} instead.`);
+    }
+
+    let version = ecmaVersion;
+
+    // Calculate ECMAScript edition number from official year version starting with
+    // ES2015, which corresponds with ES6 (or a difference of 2009).
+    if (version >= 2015) {
+        version -= 2009;
+    }
+
+    if (!SUPPORTED_VERSIONS.includes(version)) {
+        throw new Error("Invalid ecmaVersion.");
+    }
+
+    return version;
+}
+
+/**
+ * Normalize sourceType from the initial config
+ * @param {string} sourceType to normalize
+ * @throws {Error} throw an error if sourceType is invalid
+ * @returns {string} normalized sourceType
+ */
+function normalizeSourceType(sourceType = "script") {
+    if (sourceType === "script" || sourceType === "module") {
+        return sourceType;
+    }
+    throw new Error("Invalid sourceType.");
+}
+
+/**
+ * Normalize parserOptions
+ * @param {Object} options the parser options to normalize
+ * @throws {Error} throw an error if found invalid option.
+ * @returns {Object} normalized options
+ */
+function normalizeOptions(options) {
+    const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
+    const sourceType = normalizeSourceType(options.sourceType);
+    const ranges = options.range === true;
+    const locations = options.loc === true;
+
+    if (sourceType === "module" && ecmaVersion < 6) {
+        throw new Error("sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.");
+    }
+    return Object.assign({}, options, { ecmaVersion, sourceType, ranges, locations });
+}
+
+/**
+ * Get the latest ECMAScript version supported by Espree.
+ * @returns {number} The latest ECMAScript version.
+ */
+function latestEcmaVersion() {
+    return Math.max(...SUPPORTED_VERSIONS);
+}
+
+/**
+ * Get the list of ECMAScript versions supported by Espree.
+ * @returns {number[]} An array containing the supported ECMAScript versions.
+ */
+function supportedEcmaVersions() {
+    return [...SUPPORTED_VERSIONS];
+}
+
+//------------------------------------------------------------------------------
+// Public
+//------------------------------------------------------------------------------
+
+module.exports = {
+    normalizeOptions,
+    latestEcmaVersion,
+    supportedEcmaVersions
+};

--- a/tests/lib/supported-ecmaversions.js
+++ b/tests/lib/supported-ecmaversions.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Tests for getLatestEcmaVersion() & getSupportedEcmaVersions().
+ * @fileoverview Tests for latestEcmaVersion & supportedEcmaVersions.
  * @author Kai Cataldo
  */
 
@@ -16,25 +16,17 @@ const assert = require("assert"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("getLatestEcmaVersion()", () => {
+describe("latestEcmaVersion", () => {
     it("should return the latest supported ecmaVersion", () => {
-        assert.strictEqual(espree.getLatestEcmaVersion(), 11);
+        assert.strictEqual(espree.latestEcmaVersion, 11);
     });
 });
 
-describe("getSupportedEcmaVersions()", () => {
+describe("supportedEcmaVersions", () => {
     it("should return an array of all supported versions", () => {
         assert.deepStrictEqual(
-            espree.getSupportedEcmaVersions(),
+            espree.supportedEcmaVersions,
             [3, 5, 6, 7, 8, 9, 10, 11]
         );
-    });
-
-    it("the array of supported versions should not be mutable by reference", () => {
-        const supportedVersions = espree.getSupportedEcmaVersions();
-        const originalValue = [...supportedVersions];
-
-        supportedVersions.push("a", "b", "c");
-        assert.deepStrictEqual(espree.getSupportedEcmaVersions(), originalValue);
     });
 });

--- a/tests/lib/supported-ecmaversions.js
+++ b/tests/lib/supported-ecmaversions.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Tests for latestEcmaVersion() & supportedEcmaVersions().
+ * @fileoverview Tests for getLatestEcmaVersion() & getSupportedEcmaVersions().
  * @author Kai Cataldo
  */
 
@@ -16,25 +16,25 @@ const assert = require("assert"),
 // Tests
 //------------------------------------------------------------------------------
 
-describe("latestEcmaVersion()", () => {
+describe("getLatestEcmaVersion()", () => {
     it("should return the latest supported ecmaVersion", () => {
-        assert.strictEqual(espree.latestEcmaVersion(), 11);
+        assert.strictEqual(espree.getLatestEcmaVersion(), 11);
     });
 });
 
-describe("supportedEcmaVersions()", () => {
+describe("getSupportedEcmaVersions()", () => {
     it("should return an array of all supported versions", () => {
         assert.deepStrictEqual(
-            espree.supportedEcmaVersions(),
+            espree.getSupportedEcmaVersions(),
             [3, 5, 6, 7, 8, 9, 10, 11]
         );
     });
 
     it("the array of supported versions should not be mutable by reference", () => {
-        const supportedVersions = espree.supportedEcmaVersions();
+        const supportedVersions = espree.getSupportedEcmaVersions();
         const originalValue = [...supportedVersions];
 
         supportedVersions.push("a", "b", "c");
-        assert.deepStrictEqual(espree.supportedEcmaVersions(), originalValue);
+        assert.deepStrictEqual(espree.getSupportedEcmaVersions(), originalValue);
     });
 });

--- a/tests/lib/supported-ecmaversions.js
+++ b/tests/lib/supported-ecmaversions.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Tests for latestEcmaVersion() & supportedEcmaVersions().
+ * @author Kai Cataldo
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("assert"),
+    espree = require("../../espree");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("latestEcmaVersion()", () => {
+    it("should return the latest supported ecmaVersion", () => {
+        assert.strictEqual(espree.latestEcmaVersion(), 11);
+    });
+});
+
+describe("supportedEcmaVersions()", () => {
+    it("should return an array of all supported versions", () => {
+        assert.deepStrictEqual(
+            espree.supportedEcmaVersions(),
+            [3, 5, 6, 7, 8, 9, 10, 11]
+        );
+    });
+
+    it("the array of supported versions should not be mutable by reference", () => {
+        const supportedVersions = espree.supportedEcmaVersions();
+        const originalValue = [...supportedVersions];
+
+        supportedVersions.push("a", "b", "c");
+        assert.deepStrictEqual(espree.supportedEcmaVersions(), originalValue);
+    });
+});


### PR DESCRIPTION
Inspired by [this discussion](https://github.com/eslint/eslint/pull/12879#discussion_r376182196), this is a proposal to add `latestEcmaVersion()` & `supportedEcmaVersions()` to the public API.

Benefits:
1. We can query the latest `ecmaVersion` from the parser for rules (as is mentioned in the comment listed above).
1. The supported `ecmaVersion`s in our demo have gotten out of sync with ESLint core. This would allow us to calculate this programmatically and not have to manually update it.
1. This is a fairly minimal API that shouldn't require much maintenance. We will most likely adjust this code once a year.

Cons:
1. This increases the surface area of our API and will have to be maintained.

Open questions:
1. If we use this in core, are we expecting 3rd party parsers to also implement this? I would say no (and that we should always fall back to Espree in the event it doesn't exist on a 3rd party parser). I believe this is still better than it being hardcoded in core.