### PR TITLE
Upgrade: acorn to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^7.1.0",
+    "acorn": "^7.1.1",
     "acorn-jsx": "^5.2.0",
     "eslint-visitor-keys": "^1.1.0"
   },


### PR DESCRIPTION
fixes "Regular Expression Denial of Service" vulnerability (fixes #435)