### PR TITLE
Chore: Add tests for ecmaVersion default value

### DIFF
--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -17,6 +17,14 @@ const assert = require("assert"),
 //------------------------------------------------------------------------------
 
 describe("normalizeOptions", () => {
+    it("should set ecmaVersion to 5 if it wasn't specified", () => {
+        const option = {};
+
+        const output = normalizeOptions(option);
+
+        assert.strictEqual(output.ecmaVersion, 5);
+    });
+
     it("should throw error for sourceType module and ecmaVersion < 6", () => {
         const option = {
             sourceType: "module",

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -19,6 +19,21 @@ const assert = require("assert"),
 
 describe("parse()", () => {
 
+    describe("ecmaVersion", () => {
+
+        it("should be 5 if not specified", () => {
+
+            // `ecmaVersion: 3` would throw on getters/setters
+            espree.parse("var foo = { get bar() {} }");
+
+            // needs `ecmaVersion: 6` or higher
+            assert.throws(() => {
+                espree.parse("let foo");
+            });
+        });
+
+    });
+
     describe("modules", () => {
 
         it("should have correct column number when strict mode error occurs", () => {

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -19,6 +19,16 @@ const assert = require("assert"),
 
 describe("tokenize()", () => {
 
+    it("should have `ecmaVersion: 5` as default", () => {
+
+        // FIXME: is there a way to test that it isn't `ecmaVersion: 3`?
+
+        // needs `ecmaVersion: 6` or higher
+        assert.throws(() => {
+            espree.tokenize("`template`");
+        });
+    });
+
     it("should produce tokens when using let", () => {
         const tokens = espree.tokenize("let foo = bar;", {
             ecmaVersion: 6,


### PR DESCRIPTION
Adds a couple of tests to ensure that `ecmaVersion: 5` is the default. I'm not sure if we already had any explicit ones.