### PR TITLE
Breaking: syncing start/end with range (fixes #349)

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -162,10 +162,14 @@ module.exports = () => Parser => {
             if (program.range) {
                 program.range[0] = program.body.length ? program.body[0].range[0] : program.range[0];
                 program.range[1] = extra.lastToken ? extra.lastToken.range[1] : program.range[1];
+                program.start = program.range[0];
+                program.end = program.range[1];
             }
             if (program.loc) {
                 program.loc.start = program.body.length ? program.body[0].loc.start : program.loc.start;
                 program.loc.end = extra.lastToken ? extra.lastToken.loc.end : program.loc.end;
+                program.start = program.loc.start.column;
+                program.end = program.loc.end.column;
             }
 
             return program;
@@ -268,11 +272,15 @@ module.exports = () => Parser => {
                 if (result.range) {
                     result.range[0]--;
                     result.range[1] += (terminalDollarBraceL ? 2 : 1);
+                    result.start = result.range[0];
+                    result.end = result.range[1];
                 }
 
                 if (result.loc) {
                     result.loc.start.column--;
                     result.loc.end.column += (terminalDollarBraceL ? 2 : 1);
+                    result.start = result.loc.start.column;
+                    result.end = result.loc.end.column;
                 }
             }
 

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -105,7 +105,8 @@ module.exports = () => Parser => {
                 impliedStrict: ecmaFeatures.impliedStrict === true && this.options.ecmaVersion >= 5,
                 ecmaVersion: this.options.ecmaVersion,
                 jsxAttrValueToken: false,
-                lastToken: null
+                lastToken: null,
+                templateElements: []
             };
         }
 
@@ -170,6 +171,13 @@ module.exports = () => Parser => {
 
             program.start = program.body.length ? program.body[0].start : program.start;
             program.end = extra.lastToken ? extra.lastToken.end : program.end;
+
+            this[STATE].templateElements.forEach(templateElement => {
+                const terminalDollarBraceL = this.input.slice(templateElement.end, templateElement.end + 2) === "${";
+
+                templateElement.start--;
+                templateElement.end += (terminalDollarBraceL ? 2 : 1);
+            });
 
             return program;
         }
@@ -278,8 +286,7 @@ module.exports = () => Parser => {
                     result.loc.end.column += (terminalDollarBraceL ? 2 : 1);
                 }
 
-                result.start--;
-                result.end += (terminalDollarBraceL ? 2 : 1);
+                this[STATE].templateElements.push(result);
             }
 
             if (result.type.indexOf("Function") > -1 && !result.generator) {

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -162,15 +162,14 @@ module.exports = () => Parser => {
             if (program.range) {
                 program.range[0] = program.body.length ? program.body[0].range[0] : program.range[0];
                 program.range[1] = extra.lastToken ? extra.lastToken.range[1] : program.range[1];
-                program.start = program.range[0];
-                program.end = program.range[1];
             }
             if (program.loc) {
                 program.loc.start = program.body.length ? program.body[0].loc.start : program.loc.start;
                 program.loc.end = extra.lastToken ? extra.lastToken.loc.end : program.loc.end;
-                program.start = program.loc.start.column;
-                program.end = program.loc.end.column;
             }
+
+            program.start = program.body.length ? program.body[0].start : program.start;
+            program.end = extra.lastToken ? extra.lastToken.end : program.end;
 
             return program;
         }
@@ -272,16 +271,15 @@ module.exports = () => Parser => {
                 if (result.range) {
                     result.range[0]--;
                     result.range[1] += (terminalDollarBraceL ? 2 : 1);
-                    result.start = result.range[0];
-                    result.end = result.range[1];
                 }
 
                 if (result.loc) {
                     result.loc.start.column--;
                     result.loc.end.column += (terminalDollarBraceL ? 2 : 1);
-                    result.start = result.loc.start.column;
-                    result.end = result.loc.end.column;
                 }
+
+                result.start--;
+                result.end += (terminalDollarBraceL ? 2 : 1);
             }
 
             if (result.type.indexOf("Function") > -1 && !result.generator) {

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -154,6 +154,17 @@ describe("parse()", () => {
             assert.strictEqual(ast.body[0].expression.quasis[1].end, ast.body[0].expression.quasis[1].range[1]);
         });
 
+        it("should output the same value for loc, range and start and end in templateElement", () => {
+            const ast = espree.parse("`foo ${bar}`;", {
+                ecmaVersion: 6
+            });
+
+            assert.strictEqual(ast.body[0].expression.quasis[0].start, 0);
+            assert.strictEqual(ast.body[0].expression.quasis[0].end, 7);
+            assert.strictEqual(ast.body[0].expression.quasis[1].start, 10);
+            assert.strictEqual(ast.body[0].expression.quasis[1].end, 12);
+        });
+
         it("should reset lastToken on each parse", () => {
             espree.parse("var foo = bar;");
             const ast = espree.parse("//foo", {

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -78,6 +78,82 @@ describe("parse()", () => {
             assert.deepStrictEqual(tester.getRaw(ast), require("../fixtures/parse/all-pieces.json"));
         });
 
+        it("should output the same value for program.start, end and range when there is a leading/trailing comments", () => {
+            const ast = espree.parse("/* foo */ bar /* baz */", {
+                range: true
+            });
+
+            assert.strictEqual(ast.start, ast.range[0]);
+            assert.strictEqual(ast.end, ast.range[1]);
+        });
+
+        it("should output the same value for program.start, end and range and loc when there is a leading comments with range and loc true", () => {
+            const ast = espree.parse("/* foo */ bar", {
+                range: true,
+                loc: true
+            });
+
+            assert.strictEqual(ast.start, ast.range[0]);
+            assert.strictEqual(ast.end, ast.range[1]);
+            assert.strictEqual(ast.start, ast.loc.start.column);
+            assert.strictEqual(ast.end, ast.loc.end.column);
+        });
+
+        it("should output the same value for program.start, end and loc when there is a leading comments with loc", () => {
+            const ast = espree.parse("/* foo */ bar", {
+                loc: true
+            });
+
+            assert.strictEqual(ast.start, ast.loc.start.column);
+            assert.strictEqual(ast.end, ast.loc.end.column);
+        });
+
+        it("should output the same value for program.start, end and range when there is a trailing comments", () => {
+            const ast = espree.parse(" bar /* foo */", {
+                range: true
+            });
+
+            assert.strictEqual(ast.start, ast.range[0]);
+            assert.strictEqual(ast.end, ast.range[1]);
+        });
+
+        it("should output the same value for range and start and end in templateElement with range", () => {
+            const ast = espree.parse("`foo ${bar}`;", {
+                ecmaVersion: 6,
+                range: true
+            });
+
+            assert.strictEqual(ast.body[0].expression.quasis[0].start, ast.body[0].expression.quasis[0].range[0]);
+            assert.strictEqual(ast.body[0].expression.quasis[0].end, ast.body[0].expression.quasis[0].range[1]);
+            assert.strictEqual(ast.body[0].expression.quasis[1].start, ast.body[0].expression.quasis[1].range[0]);
+            assert.strictEqual(ast.body[0].expression.quasis[1].end, ast.body[0].expression.quasis[1].range[1]);
+        });
+
+        it("should output the same value for loc and start and end in templateElement with loc", () => {
+            const ast = espree.parse("`foo ${bar}`;", {
+                ecmaVersion: 6,
+                loc: true
+            });
+
+            assert.strictEqual(ast.body[0].expression.quasis[0].start, ast.body[0].expression.quasis[0].loc.start.column);
+            assert.strictEqual(ast.body[0].expression.quasis[0].end, ast.body[0].expression.quasis[0].loc.end.column);
+            assert.strictEqual(ast.body[0].expression.quasis[1].start, ast.body[0].expression.quasis[1].loc.start.column);
+            assert.strictEqual(ast.body[0].expression.quasis[1].end, ast.body[0].expression.quasis[1].loc.end.column);
+        });
+
+        it("should output the same value for loc, range and start and end in templateElement with loc and range", () => {
+            const ast = espree.parse("`foo ${bar}`;", {
+                ecmaVersion: 6,
+                loc: true,
+                range: true
+            });
+
+            assert.strictEqual(ast.body[0].expression.quasis[0].start, ast.body[0].expression.quasis[0].loc.start.column);
+            assert.strictEqual(ast.body[0].expression.quasis[0].end, ast.body[0].expression.quasis[0].loc.end.column);
+            assert.strictEqual(ast.body[0].expression.quasis[1].start, ast.body[0].expression.quasis[1].range[0]);
+            assert.strictEqual(ast.body[0].expression.quasis[1].end, ast.body[0].expression.quasis[1].range[1]);
+        });
+
         it("should reset lastToken on each parse", () => {
             espree.parse("var foo = bar;");
             const ast = espree.parse("//foo", {


### PR DESCRIPTION
Syncing the range and loc with `start` and `end` for both `program` and `templateElement` nodes. 
