### PR TITLE
Upgrade: eslint-visitor-keys@2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "acorn": "^7.4.0",
     "acorn-jsx": "^5.3.1",
-    "eslint-visitor-keys": "^1.3.0"
+    "eslint-visitor-keys": "^2.0.0"
   },
   "devDependencies": {
     "browserify": "^16.5.0",


### PR DESCRIPTION
Upgrades `eslint-visitor-keys` from `1.3.0` to `2.0.0`.

The only change in `2.0.0` was dropping support for Node < 10: https://github.com/eslint/eslint-visitor-keys/commit/fb86ca315daafc84e23ed9005db40b0892b972a6

Espree already doesn't support Node < 10:

https://github.com/eslint/espree/blob/fef6f4a2803d959304c6961527044bd9da39ac92/package.json#L12-L14