### PR TITLE
Chore: Add test for valid non-string input

### DIFF
--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -96,5 +96,14 @@ describe("parse()", () => {
             espree.parse("foo", Object.freeze({ ecmaFeatures: Object.freeze({}) }));
         });
 
+        it("Cast valid non-string input", () => {
+            const str = "var foo = bar;";
+
+            assert.deepStrictEqual(
+                espree.parse(Buffer.from(str)),
+                espree.parse(str)
+            );
+        });
+
     });
 });


### PR DESCRIPTION
Test that buffers and strings produce equal output to resolve uncovered line.