### PR TITLE
Update: Expose Acorn options (#464)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,7 +148,10 @@ const options = {
 
         // enable implied strict mode (if ecmaVersion >= 5)
         impliedStrict: false
-    }
+    },
+
+    // specify options for the internal Acorn parser
+    acornOptions: {}
 }
 ```
 

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -67,11 +67,11 @@ module.exports = () => Parser => {
             // Initialize acorn parser.
             super({
 
-                // TODO: use {...options} when spread is supported(Node.js >= 8.3.0).
-                ecmaVersion: options.ecmaVersion,
-                sourceType: options.sourceType,
-                ranges: options.ranges,
-                locations: options.locations,
+                ...options,
+
+                // Pass options directly to the underlying parser to allow
+                // for use of advanced options such as allowHashBang.
+                ...opts.acornOptions,
 
                 // Truthy value is true for backward compatibility.
                 allowReturnOutsideFunction: Boolean(ecmaFeatures.globalReturn),


### PR DESCRIPTION
Implementation of proposal #464 to expose Acorn options.

- Allow setting options for underlying Acorn parser using new acornOptions property of espree options object.
- Resolve TODO for repeated key copy as all targed versions of Node support the spread operator.
