### PR TITLE
Build: remove browserify script

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -2,7 +2,7 @@
  * @fileoverview Build file
  * @author nzakas
  */
-/* global cp, echo, exit, mkdir, rm, target, test */
+/* global cp, echo, exit, rm, target */
 
 "use strict";
 
@@ -14,15 +14,12 @@
 require("shelljs/make");
 
 const nodeCLI = require("shelljs-nodecli");
-const path = require("path");
 
 //------------------------------------------------------------------------------
 // Data
 //------------------------------------------------------------------------------
 
 const NODE_MODULES = "./node_modules/",
-    TEMP_DIR = "./tmp/",
-    BUILD_DIR = "./build/",
     DOCS_DIR = "./docs",
 
     // Utilities - intentional extra space at the end of each string
@@ -107,34 +104,4 @@ target.docs = function() {
     rm("-r", `${DOCS_DIR}/README.md`);
     cp("README.md", DOCS_DIR);
     echo("Done. ");
-};
-
-target.browserify = function() {
-
-    // 1. create temp and build directory
-    if (!test("-d", TEMP_DIR)) {
-        mkdir(TEMP_DIR);
-        mkdir(path.join(TEMP_DIR, "lib"));
-    }
-
-    if (!test("-d", BUILD_DIR)) {
-        mkdir(BUILD_DIR);
-    }
-
-    // 2. copy files into temp directory
-    cp("-r", "lib/*", path.join(TEMP_DIR, "lib"));
-    cp("espree.js", TEMP_DIR);
-    cp("package.json", TEMP_DIR);
-
-    // 3. browserify the temp directory
-    nodeCLI.exec(
-        "browserify",
-        path.join(TEMP_DIR, "espree.js"),
-        "-o",
-        path.join(BUILD_DIR, "espree.js"),
-        "-s espree"
-    );
-
-    // 4. remove temp directory
-    rm("-r", TEMP_DIR);
 };

--- a/README.md
+++ b/README.md
@@ -172,7 +172,6 @@ We work hard to ensure that Espree is safe for everyone and that security issues
 
 * `npm test` - run all linting and tests
 * `npm run lint` - run all linting
-* `npm run browserify` - creates a version of Espree that is usable in a browser
 
 ## Differences from Espree 2.x
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -130,8 +130,8 @@ const options = {
     // create a top-level tokens array containing all tokens
     tokens: false,
 
-    // Set to 3, 5 (default), 6, 7, 8, 9, or 10 to specify the version of ECMAScript syntax you want to use.
-    // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), or 2020 (same as 11) to use the year-based naming.
+    // Set to 3, 5 (default), 6, 7, 8, 9, 10, 11, or 12 to specify the version of ECMAScript syntax you want to use.
+    // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), or 2021 (same as 12) to use the year-based naming.
     ecmaVersion: 5,
 
     // specify which type of script you're parsing ("script" or "module")
@@ -164,11 +164,14 @@ Issues and pull requests will be triaged and responded to as quickly as possible
 
 Espree is licensed under a permissive BSD 2-clause license.
 
+## Security Policy
+
+We work hard to ensure that Espree is safe for everyone and that security issues are addressed quickly and responsibly. Read the full [security policy](https://github.com/eslint/.github/blob/master/SECURITY.md).
+
 ## Build Commands
 
 * `npm test` - run all linting and tests
 * `npm run lint` - run all linting
-* `npm run browserify` - creates a version of Espree that is usable in a browser
 
 ## Differences from Espree 2.x
 
@@ -213,38 +216,16 @@ Acorn is a great JavaScript parser that produces an AST that is compatible with 
 
 We are building on top of Acorn, however, so that we can contribute back and help make Acorn even better.
 
-### What ECMAScript 6 features do you support?
+### What ECMAScript features do you support?
 
-All of them.
+Espree supports all ECMAScript 2020 features and partially supports ECMAScript 2021 features.
 
-### What ECMAScript 7/2016 features do you support?
+Because ECMAScript 2021 is still under development, we are implementing features as they are finalized. Currently, Espree supports:
 
-There is only one ECMAScript 2016 syntax change: the exponentiation operator. Espree supports this.
+* [Logical Assignment Operators](https://github.com/tc39/proposal-logical-assignment)
+* [Numeric Separators](https://github.com/tc39/proposal-numeric-separator)
 
-### What ECMAScript 2017 features do you support?
-
-There are two ECMAScript 2017 syntax changes: `async` functions, and trailing commas in function declarations and calls. Espree supports both of them.
-
-### What ECMAScript 2018 features do you support?
-
-There are seven ECMAScript 2018 syntax changes:
-
-* Invalid escape sequences in tagged template literals
-* Rest/spread properties
-* Async iteration
-* RegExp `s` flag
-* RegExp named capture groups
-* RegExp lookbehind assertions
-* RegExp Unicode property escapes
-
-Espree supports all of them.
-
-### What ECMAScript 2019 features do you support?
-
-Because ECMAScript 2019 is still under development, we are implementing features as they are finalized. Currently, Espree supports:
-
-* Optional `catch` binding
-* JSON superset (`\u2028` and `\u2029` in string literals)
+See [finished-proposals.md](https://github.com/tc39/proposals/blob/master/finished-proposals.md) to know what features are finalized.
 
 ### How do you determine which experimental features to support?
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint-visitor-keys": "^2.0.0"
   },
   "devDependencies": {
-    "browserify": "^16.5.0",
     "chai": "^4.2.0",
     "eslint": "^6.0.1",
     "eslint-config-eslint": "^5.0.1",
@@ -54,7 +53,6 @@
     "lint": "node Makefile.js lint",
     "fixlint": "node Makefile.js lint --fix",
     "sync-docs": "node Makefile.js docs",
-    "browserify": "node Makefile.js browserify",
     "generate-release": "eslint-generate-release",
     "generate-alpharelease": "eslint-generate-prerelease alpha",
     "generate-betarelease": "eslint-generate-prerelease beta",


### PR DESCRIPTION
Removes browserify script.

It doesn't look like we're publishing the bundle it creates, or using the script/bundle for anything, so it seems there is no point in maintaining the script.

Note: `npm run sync-docs` updated `docs/README.md` with some unrelated changes that were not synced before.