### PR TITLE
Upgrade: eslint devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^6.0.1",
-    "eslint-config-eslint": "^5.0.1",
-    "eslint-plugin-node": "^9.1.0",
+    "eslint": "^7.20.0",
+    "eslint-config-eslint": "^7.0.0",
+    "eslint-plugin-jsdoc": "^32.0.1",
+    "eslint-plugin-node": "^11.1.0",
     "eslint-release": "^1.0.0",
     "esprima": "latest",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",

--- a/tests/lib/conditional-regex-value.js
+++ b/tests/lib/conditional-regex-value.js
@@ -4,7 +4,7 @@ module.exports = function(literalNode) {
     if (literalNode.regex) {
         try {
             literalNode.value = new RegExp(literalNode.regex.pattern, literalNode.regex.flags);
-        } catch (e) {
+        } catch {
             literalNode.value = null;
         }
     }

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -82,7 +82,7 @@ describe("ecmaVersion", () => {
 
                 try {
                     expected = require(`${path.resolve(__dirname, "../../", FIXTURES_DIR, filename)}.module-result.js`);
-                } catch (err) {
+                } catch {
                     expected = require(`${path.resolve(__dirname, "../../", FIXTURES_DIR, filename)}.result.js`);
                 }
 
@@ -124,7 +124,7 @@ describe("ecmaVersion", () => {
                         loc: true
                     }
                 );
-            }, /Invalid ecmaVersion/);
+            }, /Invalid ecmaVersion/u);
         });
 
         it("Should throw error using invalid year", () => {
@@ -138,7 +138,7 @@ describe("ecmaVersion", () => {
                         loc: true
                     }
                 );
-            }, /Invalid ecmaVersion/);
+            }, /Invalid ecmaVersion/u);
         });
 
         it("Should throw error when non-numeric year is provided", () => {
@@ -152,7 +152,7 @@ describe("ecmaVersion", () => {
                         loc: true
                     }
                 );
-            }, /ecmaVersion must be a number. Received value of type string instead/);
+            }, /ecmaVersion must be a number. Received value of type string instead/u);
         });
 
         it("Should throw error when using module in pre-ES6", () => {
@@ -163,7 +163,7 @@ describe("ecmaVersion", () => {
                         sourceType: "module"
                     }
                 );
-            }, /sourceType 'module' is not supported when ecmaVersion < 2015/);
+            }, /sourceType 'module' is not supported when ecmaVersion < 2015/u);
         });
     });
 


### PR DESCRIPTION
This PR:

* Upgrades to `eslint-config-eslint@7.0.0`, and fixes new linting errors.
* Adds `eslint-plugin-jsdoc`.
* Bumps `eslint` and `eslint-plugin-node` to the latest versions.