### PR TITLE
Build: Update branch reference in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Switches the CI references from master to main. My understanding is that this will redirect automatically even without making this change, but better to be explicit.