### PR TITLE
Chore: remove --legacy-peer-deps for Node 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,6 @@ jobs:
         node-version: ${{ matrix.node }}
     - name: Install dependencies
       run: npm install
-      if: ${{ !startswith(matrix.node, '15') }}
-    - name: Install dependencies
-      run: npm install --legacy-peer-deps
-      if: ${{ startswith(matrix.node, '15') }}  
     - name: Build commonjs
       run: npm run build
     - name: Run tests


### PR DESCRIPTION
Removes `npm install --legacy-peer-deps` for Node 15 in `ci.yml`, since the issues we had with peer dependencies have been fixed.