### PR TITLE
Chore: Refactor `TemplateElement` range fix

### DIFF
--- a/lib/espree.js
+++ b/lib/espree.js
@@ -6,6 +6,29 @@ import { normalizeOptions } from "./options.js";
 const STATE = Symbol("espree's internal state");
 const ESPRIMA_FINISH_NODE = Symbol("espree's esprimaFinishNode");
 
+/**
+ * Adjust ranges/locations/start/end of `TemplateElement`
+ * @param {TemplateElement} node The `TemplateElement` node.
+ * @returns {void}
+ * @private
+ */
+function fixTemplateElementRange(node) {
+    const startOffset = -1;
+    const endOffset = node.tail ? 1 : 2;
+
+    node.start += startOffset;
+    node.end += endOffset;
+
+    if (node.range) {
+        node.range[0] += startOffset;
+        node.range[1] += endOffset;
+    }
+
+    if (node.loc) {
+        node.loc.start.column += startOffset;
+        node.loc.end.column += endOffset;
+    }
+}
 
 /**
  * Converts an Acorn comment to a Esprima comment.
@@ -171,12 +194,7 @@ export default () => Parser => {
             program.start = program.body.length ? program.body[0].start : program.start;
             program.end = extra.lastToken ? extra.lastToken.end : program.end;
 
-            this[STATE].templateElements.forEach(templateElement => {
-                const terminalDollarBraceL = this.input.slice(templateElement.end, templateElement.end + 2) === "${";
-
-                templateElement.start--;
-                templateElement.end += (terminalDollarBraceL ? 2 : 1);
-            });
+            this[STATE].templateElements.forEach(fixTemplateElementRange);
 
             return program;
         }
@@ -271,20 +289,6 @@ export default () => Parser => {
             // Acorn doesn't count the opening and closing backticks as part of templates
             // so we have to adjust ranges/locations appropriately.
             if (result.type === "TemplateElement") {
-
-                // additional adjustment needed if ${ is the last token
-                const terminalDollarBraceL = this.input.slice(result.end, result.end + 2) === "${";
-
-                if (result.range) {
-                    result.range[0]--;
-                    result.range[1] += (terminalDollarBraceL ? 2 : 1);
-                }
-
-                if (result.loc) {
-                    result.loc.start.column--;
-                    result.loc.end.column += (terminalDollarBraceL ? 2 : 1);
-                }
-
                 this[STATE].templateElements.push(result);
             }
 

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -6,6 +6,7 @@ import { normalizeOptions } from "./options.js";
 const STATE = Symbol("espree's internal state");
 const ESPRIMA_FINISH_NODE = Symbol("espree's esprimaFinishNode");
 
+
 /**
  * Converts an Acorn comment to a Esprima comment.
  * @param {boolean} block True if it's a block comment, false if not.

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -7,30 +7,6 @@ const STATE = Symbol("espree's internal state");
 const ESPRIMA_FINISH_NODE = Symbol("espree's esprimaFinishNode");
 
 /**
- * Adjust ranges/locations/start/end of `TemplateElement`
- * @param {TemplateElement} node The `TemplateElement` node.
- * @returns {void}
- * @private
- */
-function fixTemplateElementRange(node) {
-    const startOffset = -1;
-    const endOffset = node.tail ? 1 : 2;
-
-    node.start += startOffset;
-    node.end += endOffset;
-
-    if (node.range) {
-        node.range[0] += startOffset;
-        node.range[1] += endOffset;
-    }
-
-    if (node.loc) {
-        node.loc.start.column += startOffset;
-        node.loc.end.column += endOffset;
-    }
-}
-
-/**
  * Converts an Acorn comment to a Esprima comment.
  * @param {boolean} block True if it's a block comment, false if not.
  * @param {string} text The text of the comment.
@@ -207,7 +183,23 @@ export default () => Parser => {
              * By waiting until the end of parsing, we can safely change these
              * values without affect any other part of the process.
              */
-            this[STATE].templateElements.forEach(fixTemplateElementRange);
+            this[STATE].templateElements.forEach(node => {
+                const startOffset = -1;
+                const endOffset = node.tail ? 1 : 2;
+
+                node.start += startOffset;
+                node.end += endOffset;
+
+                if (node.range) {
+                    node.range[0] += startOffset;
+                    node.range[1] += endOffset;
+                }
+
+                if (node.loc) {
+                    node.loc.start.column += startOffset;
+                    node.loc.end.column += endOffset;
+                }
+            });
 
             return program;
         }
@@ -302,6 +294,7 @@ export default () => Parser => {
             // Acorn doesn't count the opening and closing backticks as part of templates
             // so we have to adjust ranges/locations appropriately.
             if (result.type === "TemplateElement") {
+
                 // save template element references to fix start/end later
                 this[STATE].templateElements.push(result);
             }

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -184,21 +184,21 @@ export default () => Parser => {
              * By waiting until the end of parsing, we can safely change these
              * values without affect any other part of the process.
              */
-            this[STATE].templateElements.forEach(node => {
+            this[STATE].templateElements.forEach(templateElement => {
                 const startOffset = -1;
-                const endOffset = node.tail ? 1 : 2;
+                const endOffset = templateElement.tail ? 1 : 2;
 
-                node.start += startOffset;
-                node.end += endOffset;
+                templateElement.start += startOffset;
+                templateElement.end += endOffset;
 
-                if (node.range) {
-                    node.range[0] += startOffset;
-                    node.range[1] += endOffset;
+                if (templateElement.range) {
+                    templateElement.range[0] += startOffset;
+                    templateElement.range[1] += endOffset;
                 }
 
-                if (node.loc) {
-                    node.loc.start.column += startOffset;
-                    node.loc.end.column += endOffset;
+                if (templateElement.loc) {
+                    templateElement.loc.start.column += startOffset;
+                    templateElement.loc.end.column += endOffset;
                 }
             });
 


### PR DESCRIPTION
Fix ranges/locations/start/end in one step, and use `TemplateElement.tail` instead of slicing the original input.