### PR TITLE
Upgrade: eslint-release@3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^32.2.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-release": "^1.0.0",
+    "eslint-release": "^3.1.2",
     "esprima": "latest",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",
     "json-diff": "^0.5.4",


### PR DESCRIPTION
Upgrades `eslint-release` to the latest version, which supports the `main` branch.