### PR TITLE
Update: reset default ecmaVersion to 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ const options = {
     // create a top-level tokens array containing all tokens
     tokens: false,
 
-    // Set to 3, 5, 6, 7, 8, 9, 10, 11, or 12 to specify the version of ECMAScript syntax you want to use.
+    // Set to 3, 5 (the default), 6, 7, 8, 9, 10, 11, or 12 to specify the version of ECMAScript syntax you want to use.
     // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), or 2022 (same as 13) to use the year-based naming.
-    // You can also set "latest" (the default) to use the most recently supported version.
+    // You can also set "latest" to use the most recently supported version.
     ecmaVersion: 5,
 
     // specify which type of script you're parsing ("script" or "module")

--- a/lib/options.js
+++ b/lib/options.js
@@ -42,7 +42,7 @@ export function getSupportedEcmaVersions() {
  * @throws {Error} throws an error if the ecmaVersion is invalid.
  * @returns {number} normalized ECMAScript version
  */
-function normalizeEcmaVersion(ecmaVersion = getLatestEcmaVersion()) {
+function normalizeEcmaVersion(ecmaVersion = 5) {
 
     let version = ecmaVersion === "latest" ? getLatestEcmaVersion() : ecmaVersion;
 

--- a/tests/lib/ecma-version.js
+++ b/tests/lib/ecma-version.js
@@ -205,21 +205,15 @@ describe("ecmaVersion", () => {
             assert.deepStrictEqual(actual, expected);
         });
 
-        it("Should use the latestEcmaVersion as the default for ecmaVersion", () => {
-            const expected = espree.parse(
-                "let foo = bar;", {
-                    ecmaVersion: espree.latestEcmaVersion,
-                    sourceType: "module"
-                }
-            );
+        it("Should use the 5 as the default for ecmaVersion", () => {
 
-            const actual = espree.parse(
-                "let foo = bar;", {
-                    sourceType: "module"
-                }
-            );
+            assert.throws(() => {
+                espree.parse(
+                    "let foo = bar;"
+                );
 
-            assert.deepStrictEqual(actual, expected);
+            }, /Unexpected token foo/u);
+
         });
     });
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -16,12 +16,12 @@ import { normalizeOptions, getLatestEcmaVersion } from "../../lib/options.js";
 //------------------------------------------------------------------------------
 
 describe("normalizeOptions", () => {
-    it("should set ecmaVersion to latestEcmaVersion if it wasn't specified", () => {
+    it("should set ecmaVersion to 5 if it wasn't specified", () => {
         const option = {};
 
         const output = normalizeOptions(option);
 
-        assert.strictEqual(output.ecmaVersion, getLatestEcmaVersion());
+        assert.strictEqual(output.ecmaVersion, 5);
     });
 
     it("should set ecmaVersion to latestEcmaVersion if ecmaVersion: latest is passed", () => {

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -24,8 +24,14 @@ describe("parse()", () => {
     describe("ecmaVersion", () => {
 
         it("should be 5 if not specified", () => {
+
+            // needs `ecmaVersion: 5` or higher (`ecmaVersion: 3` would throw on getters/setters)
+            espree.parse("var foo = { get bar() {} }");
+
             assert.throws(() => {
                 espree.parse(
+
+                    // needs `ecmaVersion: 6` or higher
                     "let foo = bar;"
                 );
 

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -23,10 +23,14 @@ describe("parse()", () => {
 
     describe("ecmaVersion", () => {
 
-        it("should be latestEcmaVersion if not specified", () => {
+        it("should be 5 if not specified", () => {
+            assert.throws(() => {
+                espree.parse(
+                    "let foo = bar;"
+                );
 
-            // `ecmaVersion: 5` would throw on async
-            espree.parse("let foo = { async bar() {} }");
+            }, /Unexpected token foo/u);
+
         });
 
     });

--- a/tests/lib/tokenize.js
+++ b/tests/lib/tokenize.js
@@ -30,10 +30,14 @@ import tildeOperatorTokens from "../fixtures/tokenize/tilde-operator.tokens.js";
 
 describe("tokenize()", () => {
 
-    it("should have latestEcmaVersion as default", () => {
+    it("should have 5 as default", () => {
 
-        // needs `ecmaVersion: 6` or higher
-        espree.tokenize("`template`");
+        assert.throws(() => {
+
+            // needs `ecmaVersion: 6` or higher
+            espree.tokenize("`template`");
+
+        }, /Unexpected character '`'/u);
     });
 
     it("should produce tokens when using let", () => {


### PR DESCRIPTION
Per the 2021-06-17 TSC meeting, reverting so `ecmaVersion` is set to 5 if not present.