### PR TITLE
Upgrade: eslint-visitor-keys@3.0.0

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -61,7 +61,7 @@ import jsx from "acorn-jsx";
 import astNodeTypes from "./lib/ast-node-types.js";
 import espree from "./lib/espree.js";
 import espreeVersion from "./lib/version.js";
-import visitorKeys from "eslint-visitor-keys";
+import * as visitorKeys from "eslint-visitor-keys";
 import { getLatestEcmaVersion, getSupportedEcmaVersions } from "./lib/options.js";
 
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "acorn": "^8.4.1",
     "acorn-jsx": "^5.3.1",
-    "eslint-visitor-keys": "^2.1.0"
+    "eslint-visitor-keys": "^3.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Updates espree to use the new eslint-visitor-keys v3.0.0 with ESM support.