### PR TITLE
Fix: 0x2028 and 0x2029 in string literals should increment line number

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^8.4.1",
+    "acorn": "^8.5.0",
     "acorn-jsx": "^5.3.1",
     "eslint-visitor-keys": "^3.0.0"
   },

--- a/tests/fixtures/ecma-version/10/json-superset/valid-2028.result.js
+++ b/tests/fixtures/ecma-version/10/json-superset/valid-2028.result.js
@@ -6,8 +6,8 @@ export default {
             "column": 0
         },
         "end": {
-            "line": 1,
-            "column": 11
+            "line": 2,
+            "column": 1
         }
     },
     "range": [
@@ -23,8 +23,8 @@ export default {
                     "column": 0
                 },
                 "end": {
-                    "line": 1,
-                    "column": 11
+                    "line": 2,
+                    "column": 1
                 }
             },
             "range": [
@@ -40,8 +40,8 @@ export default {
                             "column": 4
                         },
                         "end": {
-                            "line": 1,
-                            "column": 11
+                            "line": 2,
+                            "column": 1
                         }
                     },
                     "range": [
@@ -74,8 +74,8 @@ export default {
                                 "column": 8
                             },
                             "end": {
-                                "line": 1,
-                                "column": 11
+                                "line": 2,
+                                "column": 1
                             }
                         },
                         "range": [
@@ -155,8 +155,8 @@ export default {
                     "column": 8
                 },
                 "end": {
-                    "line": 1,
-                    "column": 11
+                    "line": 2,
+                    "column": 1
                 }
             },
             "range": [

--- a/tests/fixtures/ecma-version/10/json-superset/valid-2029.result.js
+++ b/tests/fixtures/ecma-version/10/json-superset/valid-2029.result.js
@@ -6,8 +6,8 @@ export default {
             "column": 0
         },
         "end": {
-            "line": 1,
-            "column": 11
+            "line": 2,
+            "column": 1
         }
     },
     "range": [
@@ -23,8 +23,8 @@ export default {
                     "column": 0
                 },
                 "end": {
-                    "line": 1,
-                    "column": 11
+                    "line": 2,
+                    "column": 1
                 }
             },
             "range": [
@@ -40,8 +40,8 @@ export default {
                             "column": 4
                         },
                         "end": {
-                            "line": 1,
-                            "column": 11
+                            "line": 2,
+                            "column": 1
                         }
                     },
                     "range": [
@@ -74,8 +74,8 @@ export default {
                                 "column": 8
                             },
                             "end": {
-                                "line": 1,
-                                "column": 11
+                                "line": 2,
+                                "column": 1
                             }
                         },
                         "range": [
@@ -155,8 +155,8 @@ export default {
                     "column": 8
                 },
                 "end": {
-                    "line": 1,
-                    "column": 11
+                    "line": 2,
+                    "column": 1
                 }
             },
             "range": [

--- a/tests/fixtures/ecma-version/6/newTarget/invalid-new-target.result.js
+++ b/tests/fixtures/ecma-version/6/newTarget/invalid-new-target.result.js
@@ -2,5 +2,5 @@ export default {
     "index": 8,
     "lineNumber": 1,
     "column": 9,
-    "message": "'new.target' can only be used in functions"
+    "message": "'new.target' can only be used in functions and class static block"
 };


### PR DESCRIPTION
This PR upgrades acorn to the latest v8.5.0, which includes a bug fix https://github.com/acornjs/acorn/commit/147b99e707d145b18971c0c755b645f9afdd7180 - `0x2028` and `0x2029` source code characters should increment line numbers in `loc` even if they're in string literals.

Our tests are now updated to reflect this change.

