### PR TITLE
Chore: add class static blocks tests

### DIFF
--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-new-target.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-new-target.result.js
@@ -1,0 +1,890 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 23,
+            "column": 35
+        }
+    },
+    "range": [
+        527,
+        633
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 17
+                }
+            },
+            "range": [
+                527,
+                544
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        531,
+                        543
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            531,
+                            536
+                        ],
+                        "name": "value"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            539,
+                            543
+                        ],
+                        "value": null,
+                        "raw": "null"
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                546,
+                596
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    552,
+                    553
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    554,
+                    596
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 18,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            558,
+                            594
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 23
+                                    }
+                                },
+                                "range": [
+                                    571,
+                                    590
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 19,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 22
+                                        }
+                                    },
+                                    "range": [
+                                        571,
+                                        589
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            571,
+                                            576
+                                        ],
+                                        "name": "value"
+                                    },
+                                    "right": {
+                                        "type": "MetaProperty",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 22
+                                            }
+                                        },
+                                        "range": [
+                                            579,
+                                            589
+                                        ],
+                                        "meta": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 19,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 19,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                579,
+                                                582
+                                            ],
+                                            "name": "new"
+                                        },
+                                        "property": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 19,
+                                                    "column": 16
+                                                },
+                                                "end": {
+                                                    "line": 19,
+                                                    "column": 22
+                                                }
+                                            },
+                                            "range": [
+                                                583,
+                                                589
+                                            ],
+                                            "name": "target"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 35
+                }
+            },
+            "range": [
+                598,
+                633
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 23,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 34
+                    }
+                },
+                "range": [
+                    598,
+                    632
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 23,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        598,
+                        614
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            598,
+                            604
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            605,
+                            614
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            615,
+                            620
+                        ],
+                        "name": "value"
+                    },
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 33
+                            }
+                        },
+                        "range": [
+                            622,
+                            631
+                        ],
+                        "name": "undefined"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                527,
+                530
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 9
+                }
+            },
+            "range": [
+                531,
+                536
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 10
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                537,
+                538
+            ]
+        },
+        {
+            "type": "Null",
+            "value": "null",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 16
+                }
+            },
+            "range": [
+                539,
+                543
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 16
+                },
+                "end": {
+                    "line": 15,
+                    "column": 17
+                }
+            },
+            "range": [
+                543,
+                544
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 17,
+                    "column": 5
+                }
+            },
+            "range": [
+                546,
+                551
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 6
+                },
+                "end": {
+                    "line": 17,
+                    "column": 7
+                }
+            },
+            "range": [
+                552,
+                553
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 8
+                },
+                "end": {
+                    "line": 17,
+                    "column": 9
+                }
+            },
+            "range": [
+                554,
+                555
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 2
+                },
+                "end": {
+                    "line": 18,
+                    "column": 8
+                }
+            },
+            "range": [
+                558,
+                564
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 9
+                },
+                "end": {
+                    "line": 18,
+                    "column": 10
+                }
+            },
+            "range": [
+                565,
+                566
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 4
+                },
+                "end": {
+                    "line": 19,
+                    "column": 9
+                }
+            },
+            "range": [
+                571,
+                576
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 10
+                },
+                "end": {
+                    "line": 19,
+                    "column": 11
+                }
+            },
+            "range": [
+                577,
+                578
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "new",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 12
+                },
+                "end": {
+                    "line": 19,
+                    "column": 15
+                }
+            },
+            "range": [
+                579,
+                582
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 15
+                },
+                "end": {
+                    "line": 19,
+                    "column": 16
+                }
+            },
+            "range": [
+                582,
+                583
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "target",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 16
+                },
+                "end": {
+                    "line": 19,
+                    "column": 22
+                }
+            },
+            "range": [
+                583,
+                589
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 22
+                },
+                "end": {
+                    "line": 19,
+                    "column": 23
+                }
+            },
+            "range": [
+                589,
+                590
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 2
+                },
+                "end": {
+                    "line": 20,
+                    "column": 3
+                }
+            },
+            "range": [
+                593,
+                594
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                595,
+                596
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 6
+                }
+            },
+            "range": [
+                598,
+                604
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 6
+                },
+                "end": {
+                    "line": 23,
+                    "column": 7
+                }
+            },
+            "range": [
+                604,
+                605
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 7
+                },
+                "end": {
+                    "line": 23,
+                    "column": 16
+                }
+            },
+            "range": [
+                605,
+                614
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 16
+                },
+                "end": {
+                    "line": 23,
+                    "column": 17
+                }
+            },
+            "range": [
+                614,
+                615
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 17
+                },
+                "end": {
+                    "line": 23,
+                    "column": 22
+                }
+            },
+            "range": [
+                615,
+                620
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 22
+                },
+                "end": {
+                    "line": 23,
+                    "column": 23
+                }
+            },
+            "range": [
+                620,
+                621
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "undefined",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 24
+                },
+                "end": {
+                    "line": 23,
+                    "column": 33
+                }
+            },
+            "range": [
+                622,
+                631
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 33
+                },
+                "end": {
+                    "line": 23,
+                    "column": 34
+                }
+            },
+            "range": [
+                631,
+                632
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 34
+                },
+                "end": {
+                    "line": 23,
+                    "column": 35
+                }
+            },
+            "range": [
+                632,
+                633
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-new-target.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-new-target.src.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-operations-on-objects
+description: The "new.target" value within a static initialization block is undefined
+info: |
+  2.1.1 EvaluateStaticBlock ( receiver , blockRecord )
+
+    1. Assert: Type(receiver) is Object.
+    2. Assert: blockRecord is a ClassStaticBlockDefinition Record.
+    3. Perform ? Call(blockRecord.[[Body]], receiver).
+features: [class-static-block]
+---*/
+
+var value = null;
+
+class C {
+  static {
+    value = new.target;
+  }
+}
+
+assert.sameValue(value, undefined);

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-this.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-this.result.js
@@ -1,0 +1,764 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 23,
+            "column": 27
+        }
+    },
+    "range": [
+        521,
+        606
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                521,
+                531
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        525,
+                        530
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            525,
+                            530
+                        ],
+                        "name": "value"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                533,
+                577
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    539,
+                    540
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    541,
+                    577
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 18,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            545,
+                            575
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 17
+                                    }
+                                },
+                                "range": [
+                                    558,
+                                    571
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 19,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 16
+                                        }
+                                    },
+                                    "range": [
+                                        558,
+                                        570
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            558,
+                                            563
+                                        ],
+                                        "name": "value"
+                                    },
+                                    "right": {
+                                        "type": "ThisExpression",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 16
+                                            }
+                                        },
+                                        "range": [
+                                            566,
+                                            570
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 27
+                }
+            },
+            "range": [
+                579,
+                606
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 23,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 26
+                    }
+                },
+                "range": [
+                    579,
+                    605
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 23,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        579,
+                        595
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            579,
+                            585
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            586,
+                            595
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            596,
+                            601
+                        ],
+                        "name": "value"
+                    },
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 25
+                            }
+                        },
+                        "range": [
+                            603,
+                            604
+                        ],
+                        "name": "C"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                521,
+                524
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 9
+                }
+            },
+            "range": [
+                525,
+                530
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 9
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                530,
+                531
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 17,
+                    "column": 5
+                }
+            },
+            "range": [
+                533,
+                538
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 6
+                },
+                "end": {
+                    "line": 17,
+                    "column": 7
+                }
+            },
+            "range": [
+                539,
+                540
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 8
+                },
+                "end": {
+                    "line": 17,
+                    "column": 9
+                }
+            },
+            "range": [
+                541,
+                542
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 2
+                },
+                "end": {
+                    "line": 18,
+                    "column": 8
+                }
+            },
+            "range": [
+                545,
+                551
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 9
+                },
+                "end": {
+                    "line": 18,
+                    "column": 10
+                }
+            },
+            "range": [
+                552,
+                553
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 4
+                },
+                "end": {
+                    "line": 19,
+                    "column": 9
+                }
+            },
+            "range": [
+                558,
+                563
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 10
+                },
+                "end": {
+                    "line": 19,
+                    "column": 11
+                }
+            },
+            "range": [
+                564,
+                565
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "this",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 12
+                },
+                "end": {
+                    "line": 19,
+                    "column": 16
+                }
+            },
+            "range": [
+                566,
+                570
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 16
+                },
+                "end": {
+                    "line": 19,
+                    "column": 17
+                }
+            },
+            "range": [
+                570,
+                571
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 2
+                },
+                "end": {
+                    "line": 20,
+                    "column": 3
+                }
+            },
+            "range": [
+                574,
+                575
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                576,
+                577
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 6
+                }
+            },
+            "range": [
+                579,
+                585
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 6
+                },
+                "end": {
+                    "line": 23,
+                    "column": 7
+                }
+            },
+            "range": [
+                585,
+                586
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 7
+                },
+                "end": {
+                    "line": 23,
+                    "column": 16
+                }
+            },
+            "range": [
+                586,
+                595
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 16
+                },
+                "end": {
+                    "line": 23,
+                    "column": 17
+                }
+            },
+            "range": [
+                595,
+                596
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 17
+                },
+                "end": {
+                    "line": 23,
+                    "column": 22
+                }
+            },
+            "range": [
+                596,
+                601
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 22
+                },
+                "end": {
+                    "line": 23,
+                    "column": 23
+                }
+            },
+            "range": [
+                601,
+                602
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 24
+                },
+                "end": {
+                    "line": 23,
+                    "column": 25
+                }
+            },
+            "range": [
+                603,
+                604
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 25
+                },
+                "end": {
+                    "line": 23,
+                    "column": 26
+                }
+            },
+            "range": [
+                604,
+                605
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 26
+                },
+                "end": {
+                    "line": 23,
+                    "column": 27
+                }
+            },
+            "range": [
+                605,
+                606
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-this.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-expr-this.src.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-operations-on-objects
+description: The "this" value within a static initialization block is the class
+info: |
+  2.1.1 EvaluateStaticBlock ( receiver , blockRecord )
+
+    1. Assert: Type(receiver) is Object.
+    2. Assert: blockRecord is a ClassStaticBlockDefinition Record.
+    3. Perform ? Call(blockRecord.[[Body]], receiver).
+features: [class-static-block]
+---*/
+
+var value;
+
+class C {
+  static {
+    value = this;
+  }
+}
+
+assert.sameValue(value, C);

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-close.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-close.result.js
@@ -1,0 +1,1167 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 27,
+            "column": 39
+        }
+    },
+    "range": [
+        631,
+        808
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                631,
+                659
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        635,
+                        658
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            635,
+                            642
+                        ],
+                        "name": "test262"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 27
+                            }
+                        },
+                        "range": [
+                            645,
+                            658
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                660,
+                670
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        664,
+                        669
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            664,
+                            669
+                        ],
+                        "name": "probe"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 1
+                }
+            },
+            "range": [
+                672,
+                767
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    678,
+                    679
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 25,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    680,
+                    767
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            684,
+                            729
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32
+                                    }
+                                },
+                                "range": [
+                                    697,
+                                    725
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 31
+                                            }
+                                        },
+                                        "range": [
+                                            701,
+                                            724
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                701,
+                                                708
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 31
+                                                }
+                                            },
+                                            "range": [
+                                                711,
+                                                724
+                                            ],
+                                            "value": "first block",
+                                            "raw": "'first block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "let"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 22,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            732,
+                            765
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 23,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 20
+                                    }
+                                },
+                                "range": [
+                                    745,
+                                    761
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 23,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 23,
+                                            "column": 19
+                                        }
+                                    },
+                                    "range": [
+                                        745,
+                                        760
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 23,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 23,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            745,
+                                            750
+                                        ],
+                                        "name": "probe"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 23,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 23,
+                                                "column": 19
+                                            }
+                                        },
+                                        "range": [
+                                            753,
+                                            760
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 39
+                }
+            },
+            "range": [
+                769,
+                808
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 27,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 27,
+                        "column": 38
+                    }
+                },
+                "range": [
+                    769,
+                    807
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 27,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 27,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        769,
+                        785
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            769,
+                            775
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            776,
+                            785
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            786,
+                            791
+                        ],
+                        "name": "probe"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 37
+                            }
+                        },
+                        "range": [
+                            793,
+                            806
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                631,
+                634
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                635,
+                642
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 13
+                }
+            },
+            "range": [
+                643,
+                644
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                645,
+                658
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 27
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                658,
+                659
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                660,
+                663
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 9
+                }
+            },
+            "range": [
+                664,
+                669
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 9
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                669,
+                670
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                672,
+                677
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                678,
+                679
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 9
+                }
+            },
+            "range": [
+                680,
+                681
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                684,
+                690
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                691,
+                692
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 7
+                }
+            },
+            "range": [
+                697,
+                700
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 8
+                },
+                "end": {
+                    "line": 20,
+                    "column": 15
+                }
+            },
+            "range": [
+                701,
+                708
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 16
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            },
+            "range": [
+                709,
+                710
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 31
+                }
+            },
+            "range": [
+                711,
+                724
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 31
+                },
+                "end": {
+                    "line": 20,
+                    "column": 32
+                }
+            },
+            "range": [
+                724,
+                725
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 2
+                },
+                "end": {
+                    "line": 21,
+                    "column": 3
+                }
+            },
+            "range": [
+                728,
+                729
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 2
+                },
+                "end": {
+                    "line": 22,
+                    "column": 8
+                }
+            },
+            "range": [
+                732,
+                738
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 9
+                },
+                "end": {
+                    "line": 22,
+                    "column": 10
+                }
+            },
+            "range": [
+                739,
+                740
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 4
+                },
+                "end": {
+                    "line": 23,
+                    "column": 9
+                }
+            },
+            "range": [
+                745,
+                750
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 10
+                },
+                "end": {
+                    "line": 23,
+                    "column": 11
+                }
+            },
+            "range": [
+                751,
+                752
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 12
+                },
+                "end": {
+                    "line": 23,
+                    "column": 19
+                }
+            },
+            "range": [
+                753,
+                760
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 19
+                },
+                "end": {
+                    "line": 23,
+                    "column": 20
+                }
+            },
+            "range": [
+                760,
+                761
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 2
+                },
+                "end": {
+                    "line": 24,
+                    "column": 3
+                }
+            },
+            "range": [
+                764,
+                765
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 1
+                }
+            },
+            "range": [
+                766,
+                767
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 6
+                }
+            },
+            "range": [
+                769,
+                775
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 6
+                },
+                "end": {
+                    "line": 27,
+                    "column": 7
+                }
+            },
+            "range": [
+                775,
+                776
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 7
+                },
+                "end": {
+                    "line": 27,
+                    "column": 16
+                }
+            },
+            "range": [
+                776,
+                785
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 16
+                },
+                "end": {
+                    "line": 27,
+                    "column": 17
+                }
+            },
+            "range": [
+                785,
+                786
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 17
+                },
+                "end": {
+                    "line": 27,
+                    "column": 22
+                }
+            },
+            "range": [
+                786,
+                791
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 22
+                },
+                "end": {
+                    "line": 27,
+                    "column": 23
+                }
+            },
+            "range": [
+                791,
+                792
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 24
+                },
+                "end": {
+                    "line": 27,
+                    "column": 37
+                }
+            },
+            "range": [
+                793,
+                806
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 37
+                },
+                "end": {
+                    "line": 27,
+                    "column": 38
+                }
+            },
+            "range": [
+                806,
+                807
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 38
+                },
+                "end": {
+                    "line": 27,
+                    "column": 39
+                }
+            },
+            "range": [
+                807,
+                808
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-close.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-close.src.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Destruction of environment record for variable-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+var test262 = 'outer scope';
+var probe;
+
+class C {
+  static {
+    let test262 = 'first block';
+  }
+  static {
+    probe = test262;
+  }
+}
+
+assert.sameValue(probe, 'outer scope');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-derived.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-derived.result.js
@@ -1,0 +1,765 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 23,
+            "column": 27
+        }
+    },
+    "range": [
+        631,
+        713
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                631,
+                641
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        635,
+                        640
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            635,
+                            640
+                        ],
+                        "name": "probe"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "let"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                643,
+                684
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    649,
+                    650
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 21,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    651,
+                    684
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 18,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 20,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            655,
+                            682
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 19,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 19,
+                                        "column": 14
+                                    }
+                                },
+                                "range": [
+                                    668,
+                                    678
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 19,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 19,
+                                            "column": 13
+                                        }
+                                    },
+                                    "range": [
+                                        668,
+                                        677
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            668,
+                                            673
+                                        ],
+                                        "name": "probe"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 19,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 19,
+                                                "column": 13
+                                            }
+                                        },
+                                        "range": [
+                                            676,
+                                            677
+                                        ],
+                                        "name": "C"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 27
+                }
+            },
+            "range": [
+                686,
+                713
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 23,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 26
+                    }
+                },
+                "range": [
+                    686,
+                    712
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 23,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 23,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        686,
+                        702
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            686,
+                            692
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            693,
+                            702
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            703,
+                            708
+                        ],
+                        "name": "probe"
+                    },
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 23,
+                                "column": 25
+                            }
+                        },
+                        "range": [
+                            710,
+                            711
+                        ],
+                        "name": "C"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                631,
+                634
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 9
+                }
+            },
+            "range": [
+                635,
+                640
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 9
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                640,
+                641
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 17,
+                    "column": 5
+                }
+            },
+            "range": [
+                643,
+                648
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 6
+                },
+                "end": {
+                    "line": 17,
+                    "column": 7
+                }
+            },
+            "range": [
+                649,
+                650
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 8
+                },
+                "end": {
+                    "line": 17,
+                    "column": 9
+                }
+            },
+            "range": [
+                651,
+                652
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 2
+                },
+                "end": {
+                    "line": 18,
+                    "column": 8
+                }
+            },
+            "range": [
+                655,
+                661
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 9
+                },
+                "end": {
+                    "line": 18,
+                    "column": 10
+                }
+            },
+            "range": [
+                662,
+                663
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 4
+                },
+                "end": {
+                    "line": 19,
+                    "column": 9
+                }
+            },
+            "range": [
+                668,
+                673
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 10
+                },
+                "end": {
+                    "line": 19,
+                    "column": 11
+                }
+            },
+            "range": [
+                674,
+                675
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 12
+                },
+                "end": {
+                    "line": 19,
+                    "column": 13
+                }
+            },
+            "range": [
+                676,
+                677
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 13
+                },
+                "end": {
+                    "line": 19,
+                    "column": 14
+                }
+            },
+            "range": [
+                677,
+                678
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 2
+                },
+                "end": {
+                    "line": 20,
+                    "column": 3
+                }
+            },
+            "range": [
+                681,
+                682
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 0
+                },
+                "end": {
+                    "line": 21,
+                    "column": 1
+                }
+            },
+            "range": [
+                683,
+                684
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 6
+                }
+            },
+            "range": [
+                686,
+                692
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 6
+                },
+                "end": {
+                    "line": 23,
+                    "column": 7
+                }
+            },
+            "range": [
+                692,
+                693
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 7
+                },
+                "end": {
+                    "line": 23,
+                    "column": 16
+                }
+            },
+            "range": [
+                693,
+                702
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 16
+                },
+                "end": {
+                    "line": 23,
+                    "column": 17
+                }
+            },
+            "range": [
+                702,
+                703
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 17
+                },
+                "end": {
+                    "line": 23,
+                    "column": 22
+                }
+            },
+            "range": [
+                703,
+                708
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 22
+                },
+                "end": {
+                    "line": 23,
+                    "column": 23
+                }
+            },
+            "range": [
+                708,
+                709
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 24
+                },
+                "end": {
+                    "line": 23,
+                    "column": 25
+                }
+            },
+            "range": [
+                710,
+                711
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 25
+                },
+                "end": {
+                    "line": 23,
+                    "column": 26
+                }
+            },
+            "range": [
+                711,
+                712
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 26
+                },
+                "end": {
+                    "line": 23,
+                    "column": 27
+                }
+            },
+            "range": [
+                712,
+                713
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-derived.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-derived.src.js
@@ -1,0 +1,23 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Derivation of environment record for lexically-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+let probe;
+
+class C {
+  static {
+    probe = C;
+  }
+}
+
+assert.sameValue(probe, C);

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-open.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-open.result.js
@@ -1,0 +1,2128 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 31,
+            "column": 41
+        }
+    },
+    "range": [
+        633,
+        961
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                633,
+                661
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        637,
+                        660
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            637,
+                            644
+                        ],
+                        "name": "test262"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 27
+                            }
+                        },
+                        "range": [
+                            647,
+                            660
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                }
+            ],
+            "kind": "let"
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 19
+                }
+            },
+            "range": [
+                662,
+                681
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        666,
+                        672
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 10
+                            }
+                        },
+                        "range": [
+                            666,
+                            672
+                        ],
+                        "name": "probe1"
+                    },
+                    "init": null
+                },
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        674,
+                        680
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 18
+                            }
+                        },
+                        "range": [
+                            674,
+                            680
+                        ],
+                        "name": "probe2"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "let"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 1
+                }
+            },
+            "range": [
+                683,
+                835
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    689,
+                    690
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 27,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    691,
+                    835
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            695,
+                            762
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32
+                                    }
+                                },
+                                "range": [
+                                    708,
+                                    736
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 31
+                                            }
+                                        },
+                                        "range": [
+                                            712,
+                                            735
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                712,
+                                                719
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 31
+                                                }
+                                            },
+                                            "range": [
+                                                722,
+                                                735
+                                            ],
+                                            "value": "first block",
+                                            "raw": "'first block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "let"
+                            },
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 21,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 21
+                                    }
+                                },
+                                "range": [
+                                    741,
+                                    758
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 21,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 21,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        741,
+                                        757
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 10
+                                            }
+                                        },
+                                        "range": [
+                                            741,
+                                            747
+                                        ],
+                                        "name": "probe1"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 20
+                                            }
+                                        },
+                                        "range": [
+                                            750,
+                                            757
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            765,
+                            833
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 24,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 33
+                                    }
+                                },
+                                "range": [
+                                    778,
+                                    807
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 24,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 32
+                                            }
+                                        },
+                                        "range": [
+                                            782,
+                                            806
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 24,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                782,
+                                                789
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 24,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 32
+                                                }
+                                            },
+                                            "range": [
+                                                792,
+                                                806
+                                            ],
+                                            "value": "second block",
+                                            "raw": "'second block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "let"
+                            },
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 25,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 25,
+                                        "column": 21
+                                    }
+                                },
+                                "range": [
+                                    812,
+                                    829
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        812,
+                                        828
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 25,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 25,
+                                                "column": 10
+                                            }
+                                        },
+                                        "range": [
+                                            812,
+                                            818
+                                        ],
+                                        "name": "probe2"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 25,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 25,
+                                                "column": 20
+                                            }
+                                        },
+                                        "range": [
+                                            821,
+                                            828
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 0
+                },
+                "end": {
+                    "line": 29,
+                    "column": 41
+                }
+            },
+            "range": [
+                837,
+                878
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 29,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 29,
+                        "column": 40
+                    }
+                },
+                "range": [
+                    837,
+                    877
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 29,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 29,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        837,
+                        853
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            837,
+                            843
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            844,
+                            853
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 24
+                            }
+                        },
+                        "range": [
+                            854,
+                            861
+                        ],
+                        "name": "test262"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 26
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 39
+                            }
+                        },
+                        "range": [
+                            863,
+                            876
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 0
+                },
+                "end": {
+                    "line": 30,
+                    "column": 40
+                }
+            },
+            "range": [
+                879,
+                919
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 30,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 30,
+                        "column": 39
+                    }
+                },
+                "range": [
+                    879,
+                    918
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 30,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 30,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        879,
+                        895
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            879,
+                            885
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            886,
+                            895
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 23
+                            }
+                        },
+                        "range": [
+                            896,
+                            902
+                        ],
+                        "name": "probe1"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 25
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 38
+                            }
+                        },
+                        "range": [
+                            904,
+                            917
+                        ],
+                        "value": "first block",
+                        "raw": "'first block'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 0
+                },
+                "end": {
+                    "line": 31,
+                    "column": 41
+                }
+            },
+            "range": [
+                920,
+                961
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 31,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 31,
+                        "column": 40
+                    }
+                },
+                "range": [
+                    920,
+                    960
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 31,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 31,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        920,
+                        936
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            920,
+                            926
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            927,
+                            936
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 23
+                            }
+                        },
+                        "range": [
+                            937,
+                            943
+                        ],
+                        "name": "probe2"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 25
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 39
+                            }
+                        },
+                        "range": [
+                            945,
+                            959
+                        ],
+                        "value": "second block",
+                        "raw": "'second block'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                633,
+                636
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                637,
+                644
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 13
+                }
+            },
+            "range": [
+                645,
+                646
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                647,
+                660
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 27
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                660,
+                661
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                662,
+                665
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                666,
+                672
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 10
+                },
+                "end": {
+                    "line": 16,
+                    "column": 11
+                }
+            },
+            "range": [
+                672,
+                673
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 12
+                },
+                "end": {
+                    "line": 16,
+                    "column": 18
+                }
+            },
+            "range": [
+                674,
+                680
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 18
+                },
+                "end": {
+                    "line": 16,
+                    "column": 19
+                }
+            },
+            "range": [
+                680,
+                681
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                683,
+                688
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                689,
+                690
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 9
+                }
+            },
+            "range": [
+                691,
+                692
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                695,
+                701
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                702,
+                703
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 7
+                }
+            },
+            "range": [
+                708,
+                711
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 8
+                },
+                "end": {
+                    "line": 20,
+                    "column": 15
+                }
+            },
+            "range": [
+                712,
+                719
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 16
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            },
+            "range": [
+                720,
+                721
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 31
+                }
+            },
+            "range": [
+                722,
+                735
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 31
+                },
+                "end": {
+                    "line": 20,
+                    "column": 32
+                }
+            },
+            "range": [
+                735,
+                736
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 4
+                },
+                "end": {
+                    "line": 21,
+                    "column": 10
+                }
+            },
+            "range": [
+                741,
+                747
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 11
+                },
+                "end": {
+                    "line": 21,
+                    "column": 12
+                }
+            },
+            "range": [
+                748,
+                749
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 13
+                },
+                "end": {
+                    "line": 21,
+                    "column": 20
+                }
+            },
+            "range": [
+                750,
+                757
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 20
+                },
+                "end": {
+                    "line": 21,
+                    "column": 21
+                }
+            },
+            "range": [
+                757,
+                758
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 2
+                },
+                "end": {
+                    "line": 22,
+                    "column": 3
+                }
+            },
+            "range": [
+                761,
+                762
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 2
+                },
+                "end": {
+                    "line": 23,
+                    "column": 8
+                }
+            },
+            "range": [
+                765,
+                771
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 9
+                },
+                "end": {
+                    "line": 23,
+                    "column": 10
+                }
+            },
+            "range": [
+                772,
+                773
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 4
+                },
+                "end": {
+                    "line": 24,
+                    "column": 7
+                }
+            },
+            "range": [
+                778,
+                781
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 8
+                },
+                "end": {
+                    "line": 24,
+                    "column": 15
+                }
+            },
+            "range": [
+                782,
+                789
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 16
+                },
+                "end": {
+                    "line": 24,
+                    "column": 17
+                }
+            },
+            "range": [
+                790,
+                791
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 18
+                },
+                "end": {
+                    "line": 24,
+                    "column": 32
+                }
+            },
+            "range": [
+                792,
+                806
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 32
+                },
+                "end": {
+                    "line": 24,
+                    "column": 33
+                }
+            },
+            "range": [
+                806,
+                807
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 4
+                },
+                "end": {
+                    "line": 25,
+                    "column": 10
+                }
+            },
+            "range": [
+                812,
+                818
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 11
+                },
+                "end": {
+                    "line": 25,
+                    "column": 12
+                }
+            },
+            "range": [
+                819,
+                820
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 13
+                },
+                "end": {
+                    "line": 25,
+                    "column": 20
+                }
+            },
+            "range": [
+                821,
+                828
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 20
+                },
+                "end": {
+                    "line": 25,
+                    "column": 21
+                }
+            },
+            "range": [
+                828,
+                829
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 26,
+                    "column": 2
+                },
+                "end": {
+                    "line": 26,
+                    "column": 3
+                }
+            },
+            "range": [
+                832,
+                833
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 1
+                }
+            },
+            "range": [
+                834,
+                835
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 0
+                },
+                "end": {
+                    "line": 29,
+                    "column": 6
+                }
+            },
+            "range": [
+                837,
+                843
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 6
+                },
+                "end": {
+                    "line": 29,
+                    "column": 7
+                }
+            },
+            "range": [
+                843,
+                844
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 7
+                },
+                "end": {
+                    "line": 29,
+                    "column": 16
+                }
+            },
+            "range": [
+                844,
+                853
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 16
+                },
+                "end": {
+                    "line": 29,
+                    "column": 17
+                }
+            },
+            "range": [
+                853,
+                854
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 17
+                },
+                "end": {
+                    "line": 29,
+                    "column": 24
+                }
+            },
+            "range": [
+                854,
+                861
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 24
+                },
+                "end": {
+                    "line": 29,
+                    "column": 25
+                }
+            },
+            "range": [
+                861,
+                862
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 26
+                },
+                "end": {
+                    "line": 29,
+                    "column": 39
+                }
+            },
+            "range": [
+                863,
+                876
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 39
+                },
+                "end": {
+                    "line": 29,
+                    "column": 40
+                }
+            },
+            "range": [
+                876,
+                877
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 40
+                },
+                "end": {
+                    "line": 29,
+                    "column": 41
+                }
+            },
+            "range": [
+                877,
+                878
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 0
+                },
+                "end": {
+                    "line": 30,
+                    "column": 6
+                }
+            },
+            "range": [
+                879,
+                885
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 6
+                },
+                "end": {
+                    "line": 30,
+                    "column": 7
+                }
+            },
+            "range": [
+                885,
+                886
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 7
+                },
+                "end": {
+                    "line": 30,
+                    "column": 16
+                }
+            },
+            "range": [
+                886,
+                895
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 16
+                },
+                "end": {
+                    "line": 30,
+                    "column": 17
+                }
+            },
+            "range": [
+                895,
+                896
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 17
+                },
+                "end": {
+                    "line": 30,
+                    "column": 23
+                }
+            },
+            "range": [
+                896,
+                902
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 23
+                },
+                "end": {
+                    "line": 30,
+                    "column": 24
+                }
+            },
+            "range": [
+                902,
+                903
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 25
+                },
+                "end": {
+                    "line": 30,
+                    "column": 38
+                }
+            },
+            "range": [
+                904,
+                917
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 38
+                },
+                "end": {
+                    "line": 30,
+                    "column": 39
+                }
+            },
+            "range": [
+                917,
+                918
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 39
+                },
+                "end": {
+                    "line": 30,
+                    "column": 40
+                }
+            },
+            "range": [
+                918,
+                919
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 0
+                },
+                "end": {
+                    "line": 31,
+                    "column": 6
+                }
+            },
+            "range": [
+                920,
+                926
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 6
+                },
+                "end": {
+                    "line": 31,
+                    "column": 7
+                }
+            },
+            "range": [
+                926,
+                927
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 7
+                },
+                "end": {
+                    "line": 31,
+                    "column": 16
+                }
+            },
+            "range": [
+                927,
+                936
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 16
+                },
+                "end": {
+                    "line": 31,
+                    "column": 17
+                }
+            },
+            "range": [
+                936,
+                937
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 17
+                },
+                "end": {
+                    "line": 31,
+                    "column": 23
+                }
+            },
+            "range": [
+                937,
+                943
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 23
+                },
+                "end": {
+                    "line": 31,
+                    "column": 24
+                }
+            },
+            "range": [
+                943,
+                944
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 25
+                },
+                "end": {
+                    "line": 31,
+                    "column": 39
+                }
+            },
+            "range": [
+                945,
+                959
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 39
+                },
+                "end": {
+                    "line": 31,
+                    "column": 40
+                }
+            },
+            "range": [
+                959,
+                960
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 40
+                },
+                "end": {
+                    "line": 31,
+                    "column": 41
+                }
+            },
+            "range": [
+                960,
+                961
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-open.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-lex-open.src.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Creation of new environment record for lexically-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+let test262 = 'outer scope';
+let probe1, probe2;
+
+class C {
+  static {
+    let test262 = 'first block';
+    probe1 = test262;
+  }
+  static {
+    let test262 = 'second block';
+    probe2 = test262;
+  }
+}
+
+assert.sameValue(test262, 'outer scope');
+assert.sameValue(probe1, 'first block');
+assert.sameValue(probe2, 'second block');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-private.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-private.result.js
@@ -1,0 +1,985 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 25,
+            "column": 35
+        }
+    },
+    "range": [
+        646,
+        777
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                646,
+                656
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        650,
+                        655
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            650,
+                            655
+                        ],
+                        "name": "probe"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 1
+                }
+            },
+            "range": [
+                658,
+                740
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 17,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    664,
+                    665
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 17,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 23,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    666,
+                    740
+                ],
+                "body": [
+                    {
+                        "type": "PropertyDefinition",
+                        "loc": {
+                            "start": {
+                                "line": 18,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 18,
+                                "column": 30
+                            }
+                        },
+                        "range": [
+                            670,
+                            698
+                        ],
+                        "static": true,
+                        "computed": false,
+                        "key": {
+                            "type": "PrivateIdentifier",
+                            "loc": {
+                                "start": {
+                                    "line": 18,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 17
+                                }
+                            },
+                            "range": [
+                                677,
+                                685
+                            ],
+                            "name": "test262"
+                        },
+                        "value": {
+                            "type": "Literal",
+                            "loc": {
+                                "start": {
+                                    "line": 18,
+                                    "column": 20
+                                },
+                                "end": {
+                                    "line": 18,
+                                    "column": 29
+                                }
+                            },
+                            "range": [
+                                688,
+                                697
+                            ],
+                            "value": "private",
+                            "raw": "'private'"
+                        }
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 20,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            702,
+                            738
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 21,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 23
+                                    }
+                                },
+                                "range": [
+                                    715,
+                                    734
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 21,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 21,
+                                            "column": 22
+                                        }
+                                    },
+                                    "range": [
+                                        715,
+                                        733
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            715,
+                                            720
+                                        ],
+                                        "name": "probe"
+                                    },
+                                    "right": {
+                                        "type": "MemberExpression",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 22
+                                            }
+                                        },
+                                        "range": [
+                                            723,
+                                            733
+                                        ],
+                                        "object": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 21,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 21,
+                                                    "column": 13
+                                                }
+                                            },
+                                            "range": [
+                                                723,
+                                                724
+                                            ],
+                                            "name": "C"
+                                        },
+                                        "property": {
+                                            "type": "PrivateIdentifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 21,
+                                                    "column": 14
+                                                },
+                                                "end": {
+                                                    "line": 21,
+                                                    "column": 22
+                                                }
+                                            },
+                                            "range": [
+                                                725,
+                                                733
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "computed": false,
+                                        "optional": false
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 35
+                }
+            },
+            "range": [
+                742,
+                777
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 25,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 25,
+                        "column": 34
+                    }
+                },
+                "range": [
+                    742,
+                    776
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 25,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 25,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        742,
+                        758
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 25,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            742,
+                            748
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 25,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            749,
+                            758
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 25,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            759,
+                            764
+                        ],
+                        "name": "probe"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 25,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 33
+                            }
+                        },
+                        "range": [
+                            766,
+                            775
+                        ],
+                        "value": "private",
+                        "raw": "'private'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                646,
+                649
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 9
+                }
+            },
+            "range": [
+                650,
+                655
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 9
+                },
+                "end": {
+                    "line": 15,
+                    "column": 10
+                }
+            },
+            "range": [
+                655,
+                656
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 0
+                },
+                "end": {
+                    "line": 17,
+                    "column": 5
+                }
+            },
+            "range": [
+                658,
+                663
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 6
+                },
+                "end": {
+                    "line": 17,
+                    "column": 7
+                }
+            },
+            "range": [
+                664,
+                665
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 8
+                },
+                "end": {
+                    "line": 17,
+                    "column": 9
+                }
+            },
+            "range": [
+                666,
+                667
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 2
+                },
+                "end": {
+                    "line": 18,
+                    "column": 8
+                }
+            },
+            "range": [
+                670,
+                676
+            ]
+        },
+        {
+            "type": "PrivateIdentifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 9
+                },
+                "end": {
+                    "line": 18,
+                    "column": 17
+                }
+            },
+            "range": [
+                677,
+                685
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 18
+                },
+                "end": {
+                    "line": 18,
+                    "column": 19
+                }
+            },
+            "range": [
+                686,
+                687
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'private'",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 20
+                },
+                "end": {
+                    "line": 18,
+                    "column": 29
+                }
+            },
+            "range": [
+                688,
+                697
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 29
+                },
+                "end": {
+                    "line": 18,
+                    "column": 30
+                }
+            },
+            "range": [
+                697,
+                698
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 2
+                },
+                "end": {
+                    "line": 20,
+                    "column": 8
+                }
+            },
+            "range": [
+                702,
+                708
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 9
+                },
+                "end": {
+                    "line": 20,
+                    "column": 10
+                }
+            },
+            "range": [
+                709,
+                710
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 4
+                },
+                "end": {
+                    "line": 21,
+                    "column": 9
+                }
+            },
+            "range": [
+                715,
+                720
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 10
+                },
+                "end": {
+                    "line": 21,
+                    "column": 11
+                }
+            },
+            "range": [
+                721,
+                722
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 12
+                },
+                "end": {
+                    "line": 21,
+                    "column": 13
+                }
+            },
+            "range": [
+                723,
+                724
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 13
+                },
+                "end": {
+                    "line": 21,
+                    "column": 14
+                }
+            },
+            "range": [
+                724,
+                725
+            ]
+        },
+        {
+            "type": "PrivateIdentifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 14
+                },
+                "end": {
+                    "line": 21,
+                    "column": 22
+                }
+            },
+            "range": [
+                725,
+                733
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 22
+                },
+                "end": {
+                    "line": 21,
+                    "column": 23
+                }
+            },
+            "range": [
+                733,
+                734
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 2
+                },
+                "end": {
+                    "line": 22,
+                    "column": 3
+                }
+            },
+            "range": [
+                737,
+                738
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 0
+                },
+                "end": {
+                    "line": 23,
+                    "column": 1
+                }
+            },
+            "range": [
+                739,
+                740
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 6
+                }
+            },
+            "range": [
+                742,
+                748
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 6
+                },
+                "end": {
+                    "line": 25,
+                    "column": 7
+                }
+            },
+            "range": [
+                748,
+                749
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 7
+                },
+                "end": {
+                    "line": 25,
+                    "column": 16
+                }
+            },
+            "range": [
+                749,
+                758
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 16
+                },
+                "end": {
+                    "line": 25,
+                    "column": 17
+                }
+            },
+            "range": [
+                758,
+                759
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 17
+                },
+                "end": {
+                    "line": 25,
+                    "column": 22
+                }
+            },
+            "range": [
+                759,
+                764
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 22
+                },
+                "end": {
+                    "line": 25,
+                    "column": 23
+                }
+            },
+            "range": [
+                764,
+                765
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'private'",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 24
+                },
+                "end": {
+                    "line": 25,
+                    "column": 33
+                }
+            },
+            "range": [
+                766,
+                775
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 33
+                },
+                "end": {
+                    "line": 25,
+                    "column": 34
+                }
+            },
+            "range": [
+                775,
+                776
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 34
+                },
+                "end": {
+                    "line": 25,
+                    "column": 35
+                }
+            },
+            "range": [
+                776,
+                777
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-private.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-private.src.js
@@ -1,0 +1,25 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Shares environment record for privately-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-fields-private, class-static-block]
+---*/
+
+var probe;
+
+class C {
+  static #test262 = 'private';
+
+  static {
+    probe = C.#test262;
+  }
+}
+
+assert.sameValue(probe, 'private');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-close.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-close.result.js
@@ -1,0 +1,1167 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 27,
+            "column": 39
+        }
+    },
+    "range": [
+        631,
+        808
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                631,
+                659
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        635,
+                        658
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            635,
+                            642
+                        ],
+                        "name": "test262"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 27
+                            }
+                        },
+                        "range": [
+                            645,
+                            658
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                660,
+                670
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        664,
+                        669
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            664,
+                            669
+                        ],
+                        "name": "probe"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 1
+                }
+            },
+            "range": [
+                672,
+                767
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    678,
+                    679
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 25,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    680,
+                    767
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            684,
+                            729
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32
+                                    }
+                                },
+                                "range": [
+                                    697,
+                                    725
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 31
+                                            }
+                                        },
+                                        "range": [
+                                            701,
+                                            724
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                701,
+                                                708
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 31
+                                                }
+                                            },
+                                            "range": [
+                                                711,
+                                                724
+                                            ],
+                                            "value": "first block",
+                                            "raw": "'first block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "var"
+                            }
+                        ]
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 22,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            732,
+                            765
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 23,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 23,
+                                        "column": 20
+                                    }
+                                },
+                                "range": [
+                                    745,
+                                    761
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 23,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 23,
+                                            "column": 19
+                                        }
+                                    },
+                                    "range": [
+                                        745,
+                                        760
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 23,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 23,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            745,
+                                            750
+                                        ],
+                                        "name": "probe"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 23,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 23,
+                                                "column": 19
+                                            }
+                                        },
+                                        "range": [
+                                            753,
+                                            760
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 39
+                }
+            },
+            "range": [
+                769,
+                808
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 27,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 27,
+                        "column": 38
+                    }
+                },
+                "range": [
+                    769,
+                    807
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 27,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 27,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        769,
+                        785
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            769,
+                            775
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            776,
+                            785
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            786,
+                            791
+                        ],
+                        "name": "probe"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 27,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 27,
+                                "column": 37
+                            }
+                        },
+                        "range": [
+                            793,
+                            806
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                631,
+                634
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                635,
+                642
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 13
+                }
+            },
+            "range": [
+                643,
+                644
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                645,
+                658
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 27
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                658,
+                659
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                660,
+                663
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 9
+                }
+            },
+            "range": [
+                664,
+                669
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 9
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                669,
+                670
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                672,
+                677
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                678,
+                679
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 9
+                }
+            },
+            "range": [
+                680,
+                681
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                684,
+                690
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                691,
+                692
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 7
+                }
+            },
+            "range": [
+                697,
+                700
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 8
+                },
+                "end": {
+                    "line": 20,
+                    "column": 15
+                }
+            },
+            "range": [
+                701,
+                708
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 16
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            },
+            "range": [
+                709,
+                710
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 31
+                }
+            },
+            "range": [
+                711,
+                724
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 31
+                },
+                "end": {
+                    "line": 20,
+                    "column": 32
+                }
+            },
+            "range": [
+                724,
+                725
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 2
+                },
+                "end": {
+                    "line": 21,
+                    "column": 3
+                }
+            },
+            "range": [
+                728,
+                729
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 2
+                },
+                "end": {
+                    "line": 22,
+                    "column": 8
+                }
+            },
+            "range": [
+                732,
+                738
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 9
+                },
+                "end": {
+                    "line": 22,
+                    "column": 10
+                }
+            },
+            "range": [
+                739,
+                740
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 4
+                },
+                "end": {
+                    "line": 23,
+                    "column": 9
+                }
+            },
+            "range": [
+                745,
+                750
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 10
+                },
+                "end": {
+                    "line": 23,
+                    "column": 11
+                }
+            },
+            "range": [
+                751,
+                752
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 12
+                },
+                "end": {
+                    "line": 23,
+                    "column": 19
+                }
+            },
+            "range": [
+                753,
+                760
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 19
+                },
+                "end": {
+                    "line": 23,
+                    "column": 20
+                }
+            },
+            "range": [
+                760,
+                761
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 2
+                },
+                "end": {
+                    "line": 24,
+                    "column": 3
+                }
+            },
+            "range": [
+                764,
+                765
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 0
+                },
+                "end": {
+                    "line": 25,
+                    "column": 1
+                }
+            },
+            "range": [
+                766,
+                767
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 6
+                }
+            },
+            "range": [
+                769,
+                775
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 6
+                },
+                "end": {
+                    "line": 27,
+                    "column": 7
+                }
+            },
+            "range": [
+                775,
+                776
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 7
+                },
+                "end": {
+                    "line": 27,
+                    "column": 16
+                }
+            },
+            "range": [
+                776,
+                785
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 16
+                },
+                "end": {
+                    "line": 27,
+                    "column": 17
+                }
+            },
+            "range": [
+                785,
+                786
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 17
+                },
+                "end": {
+                    "line": 27,
+                    "column": 22
+                }
+            },
+            "range": [
+                786,
+                791
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 22
+                },
+                "end": {
+                    "line": 27,
+                    "column": 23
+                }
+            },
+            "range": [
+                791,
+                792
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 24
+                },
+                "end": {
+                    "line": 27,
+                    "column": 37
+                }
+            },
+            "range": [
+                793,
+                806
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 37
+                },
+                "end": {
+                    "line": 27,
+                    "column": 38
+                }
+            },
+            "range": [
+                806,
+                807
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 38
+                },
+                "end": {
+                    "line": 27,
+                    "column": 39
+                }
+            },
+            "range": [
+                807,
+                808
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-close.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-close.src.js
@@ -1,0 +1,27 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Destruction of environment record for variable-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+var test262 = 'outer scope';
+var probe;
+
+class C {
+  static {
+    var test262 = 'first block';
+  }
+  static {
+    probe = test262;
+  }
+}
+
+assert.sameValue(probe, 'outer scope');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-derived.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-derived.result.js
@@ -1,0 +1,930 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 24,
+            "column": 39
+        }
+    },
+    "range": [
+        630,
+        759
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                630,
+                658
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        634,
+                        657
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            634,
+                            641
+                        ],
+                        "name": "test262"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 27
+                            }
+                        },
+                        "range": [
+                            644,
+                            657
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                659,
+                669
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        663,
+                        668
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            663,
+                            668
+                        ],
+                        "name": "probe"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 1
+                }
+            },
+            "range": [
+                671,
+                718
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    677,
+                    678
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    679,
+                    718
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            683,
+                            716
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 20
+                                    }
+                                },
+                                "range": [
+                                    696,
+                                    712
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 20,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 19
+                                        }
+                                    },
+                                    "range": [
+                                        696,
+                                        711
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            696,
+                                            701
+                                        ],
+                                        "name": "probe"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 19
+                                            }
+                                        },
+                                        "range": [
+                                            704,
+                                            711
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 24,
+                    "column": 39
+                }
+            },
+            "range": [
+                720,
+                759
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 24,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 24,
+                        "column": 38
+                    }
+                },
+                "range": [
+                    720,
+                    758
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 24,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        720,
+                        736
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            720,
+                            726
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            727,
+                            736
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            737,
+                            742
+                        ],
+                        "name": "probe"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 37
+                            }
+                        },
+                        "range": [
+                            744,
+                            757
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                630,
+                633
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                634,
+                641
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 13
+                }
+            },
+            "range": [
+                642,
+                643
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                644,
+                657
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 27
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                657,
+                658
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                659,
+                662
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 9
+                }
+            },
+            "range": [
+                663,
+                668
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 9
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                668,
+                669
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                671,
+                676
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                677,
+                678
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 9
+                }
+            },
+            "range": [
+                679,
+                680
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                683,
+                689
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                690,
+                691
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 9
+                }
+            },
+            "range": [
+                696,
+                701
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 10
+                },
+                "end": {
+                    "line": 20,
+                    "column": 11
+                }
+            },
+            "range": [
+                702,
+                703
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 12
+                },
+                "end": {
+                    "line": 20,
+                    "column": 19
+                }
+            },
+            "range": [
+                704,
+                711
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 19
+                },
+                "end": {
+                    "line": 20,
+                    "column": 20
+                }
+            },
+            "range": [
+                711,
+                712
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 2
+                },
+                "end": {
+                    "line": 21,
+                    "column": 3
+                }
+            },
+            "range": [
+                715,
+                716
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 1
+                }
+            },
+            "range": [
+                717,
+                718
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 24,
+                    "column": 6
+                }
+            },
+            "range": [
+                720,
+                726
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 6
+                },
+                "end": {
+                    "line": 24,
+                    "column": 7
+                }
+            },
+            "range": [
+                726,
+                727
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 7
+                },
+                "end": {
+                    "line": 24,
+                    "column": 16
+                }
+            },
+            "range": [
+                727,
+                736
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 16
+                },
+                "end": {
+                    "line": 24,
+                    "column": 17
+                }
+            },
+            "range": [
+                736,
+                737
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 17
+                },
+                "end": {
+                    "line": 24,
+                    "column": 22
+                }
+            },
+            "range": [
+                737,
+                742
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 22
+                },
+                "end": {
+                    "line": 24,
+                    "column": 23
+                }
+            },
+            "range": [
+                742,
+                743
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 24
+                },
+                "end": {
+                    "line": 24,
+                    "column": 37
+                }
+            },
+            "range": [
+                744,
+                757
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 37
+                },
+                "end": {
+                    "line": 24,
+                    "column": 38
+                }
+            },
+            "range": [
+                757,
+                758
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 38
+                },
+                "end": {
+                    "line": 24,
+                    "column": 39
+                }
+            },
+            "range": [
+                758,
+                759
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-derived.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-derived.src.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Derivation of environment record for variable-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+var test262 = 'outer scope';
+var probe;
+
+class C {
+  static {
+    probe = test262;
+  }
+}
+
+assert.sameValue(probe, 'outer scope');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-open.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-open.result.js
@@ -1,0 +1,2128 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 15,
+            "column": 0
+        },
+        "end": {
+            "line": 31,
+            "column": 41
+        }
+    },
+    "range": [
+        632,
+        960
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                632,
+                660
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 27
+                        }
+                    },
+                    "range": [
+                        636,
+                        659
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            636,
+                            643
+                        ],
+                        "name": "test262"
+                    },
+                    "init": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 14
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 27
+                            }
+                        },
+                        "range": [
+                            646,
+                            659
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 19
+                }
+            },
+            "range": [
+                661,
+                680
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 10
+                        }
+                    },
+                    "range": [
+                        665,
+                        671
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 10
+                            }
+                        },
+                        "range": [
+                            665,
+                            671
+                        ],
+                        "name": "probe1"
+                    },
+                    "init": null
+                },
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 12
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 18
+                        }
+                    },
+                    "range": [
+                        673,
+                        679
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 12
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 18
+                            }
+                        },
+                        "range": [
+                            673,
+                            679
+                        ],
+                        "name": "probe2"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 1
+                }
+            },
+            "range": [
+                682,
+                834
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    688,
+                    689
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 27,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    690,
+                    834
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            694,
+                            761
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 32
+                                    }
+                                },
+                                "range": [
+                                    707,
+                                    735
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 31
+                                            }
+                                        },
+                                        "range": [
+                                            711,
+                                            734
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                711,
+                                                718
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 31
+                                                }
+                                            },
+                                            "range": [
+                                                721,
+                                                734
+                                            ],
+                                            "value": "first block",
+                                            "raw": "'first block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "var"
+                            },
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 21,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 21,
+                                        "column": 21
+                                    }
+                                },
+                                "range": [
+                                    740,
+                                    757
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 21,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 21,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        740,
+                                        756
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 10
+                                            }
+                                        },
+                                        "range": [
+                                            740,
+                                            746
+                                        ],
+                                        "name": "probe1"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 21,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 21,
+                                                "column": 20
+                                            }
+                                        },
+                                        "range": [
+                                            749,
+                                            756
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 23,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 26,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            764,
+                            832
+                        ],
+                        "body": [
+                            {
+                                "type": "VariableDeclaration",
+                                "loc": {
+                                    "start": {
+                                        "line": 24,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 24,
+                                        "column": 33
+                                    }
+                                },
+                                "range": [
+                                    777,
+                                    806
+                                ],
+                                "declarations": [
+                                    {
+                                        "type": "VariableDeclarator",
+                                        "loc": {
+                                            "start": {
+                                                "line": 24,
+                                                "column": 8
+                                            },
+                                            "end": {
+                                                "line": 24,
+                                                "column": 32
+                                            }
+                                        },
+                                        "range": [
+                                            781,
+                                            805
+                                        ],
+                                        "id": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 24,
+                                                    "column": 8
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 15
+                                                }
+                                            },
+                                            "range": [
+                                                781,
+                                                788
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "init": {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 24,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 24,
+                                                    "column": 32
+                                                }
+                                            },
+                                            "range": [
+                                                791,
+                                                805
+                                            ],
+                                            "value": "second block",
+                                            "raw": "'second block'"
+                                        }
+                                    }
+                                ],
+                                "kind": "var"
+                            },
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 25,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 25,
+                                        "column": 21
+                                    }
+                                },
+                                "range": [
+                                    811,
+                                    828
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        811,
+                                        827
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 25,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 25,
+                                                "column": 10
+                                            }
+                                        },
+                                        "range": [
+                                            811,
+                                            817
+                                        ],
+                                        "name": "probe2"
+                                    },
+                                    "right": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 25,
+                                                "column": 13
+                                            },
+                                            "end": {
+                                                "line": 25,
+                                                "column": 20
+                                            }
+                                        },
+                                        "range": [
+                                            820,
+                                            827
+                                        ],
+                                        "name": "test262"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 0
+                },
+                "end": {
+                    "line": 29,
+                    "column": 41
+                }
+            },
+            "range": [
+                836,
+                877
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 29,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 29,
+                        "column": 40
+                    }
+                },
+                "range": [
+                    836,
+                    876
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 29,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 29,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        836,
+                        852
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            836,
+                            842
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            843,
+                            852
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 24
+                            }
+                        },
+                        "range": [
+                            853,
+                            860
+                        ],
+                        "name": "test262"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 26
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 39
+                            }
+                        },
+                        "range": [
+                            862,
+                            875
+                        ],
+                        "value": "outer scope",
+                        "raw": "'outer scope'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 0
+                },
+                "end": {
+                    "line": 30,
+                    "column": 40
+                }
+            },
+            "range": [
+                878,
+                918
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 30,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 30,
+                        "column": 39
+                    }
+                },
+                "range": [
+                    878,
+                    917
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 30,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 30,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        878,
+                        894
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            878,
+                            884
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            885,
+                            894
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 23
+                            }
+                        },
+                        "range": [
+                            895,
+                            901
+                        ],
+                        "name": "probe1"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 25
+                            },
+                            "end": {
+                                "line": 30,
+                                "column": 38
+                            }
+                        },
+                        "range": [
+                            903,
+                            916
+                        ],
+                        "value": "first block",
+                        "raw": "'first block'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 0
+                },
+                "end": {
+                    "line": 31,
+                    "column": 41
+                }
+            },
+            "range": [
+                919,
+                960
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 31,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 31,
+                        "column": 40
+                    }
+                },
+                "range": [
+                    919,
+                    959
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 31,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 31,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        919,
+                        935
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            919,
+                            925
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            926,
+                            935
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 23
+                            }
+                        },
+                        "range": [
+                            936,
+                            942
+                        ],
+                        "name": "probe2"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 31,
+                                "column": 25
+                            },
+                            "end": {
+                                "line": 31,
+                                "column": 39
+                            }
+                        },
+                        "range": [
+                            944,
+                            958
+                        ],
+                        "value": "second block",
+                        "raw": "'second block'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 3
+                }
+            },
+            "range": [
+                632,
+                635
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 4
+                },
+                "end": {
+                    "line": 15,
+                    "column": 11
+                }
+            },
+            "range": [
+                636,
+                643
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 12
+                },
+                "end": {
+                    "line": 15,
+                    "column": 13
+                }
+            },
+            "range": [
+                644,
+                645
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 14
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                646,
+                659
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 27
+                },
+                "end": {
+                    "line": 15,
+                    "column": 28
+                }
+            },
+            "range": [
+                659,
+                660
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                661,
+                664
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                665,
+                671
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 10
+                },
+                "end": {
+                    "line": 16,
+                    "column": 11
+                }
+            },
+            "range": [
+                671,
+                672
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 12
+                },
+                "end": {
+                    "line": 16,
+                    "column": 18
+                }
+            },
+            "range": [
+                673,
+                679
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 18
+                },
+                "end": {
+                    "line": 16,
+                    "column": 19
+                }
+            },
+            "range": [
+                679,
+                680
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                682,
+                687
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                688,
+                689
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 9
+                }
+            },
+            "range": [
+                690,
+                691
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                694,
+                700
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                701,
+                702
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 7
+                }
+            },
+            "range": [
+                707,
+                710
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 8
+                },
+                "end": {
+                    "line": 20,
+                    "column": 15
+                }
+            },
+            "range": [
+                711,
+                718
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 16
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            },
+            "range": [
+                719,
+                720
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 31
+                }
+            },
+            "range": [
+                721,
+                734
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 31
+                },
+                "end": {
+                    "line": 20,
+                    "column": 32
+                }
+            },
+            "range": [
+                734,
+                735
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 4
+                },
+                "end": {
+                    "line": 21,
+                    "column": 10
+                }
+            },
+            "range": [
+                740,
+                746
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 11
+                },
+                "end": {
+                    "line": 21,
+                    "column": 12
+                }
+            },
+            "range": [
+                747,
+                748
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 13
+                },
+                "end": {
+                    "line": 21,
+                    "column": 20
+                }
+            },
+            "range": [
+                749,
+                756
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 20
+                },
+                "end": {
+                    "line": 21,
+                    "column": 21
+                }
+            },
+            "range": [
+                756,
+                757
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 2
+                },
+                "end": {
+                    "line": 22,
+                    "column": 3
+                }
+            },
+            "range": [
+                760,
+                761
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 2
+                },
+                "end": {
+                    "line": 23,
+                    "column": 8
+                }
+            },
+            "range": [
+                764,
+                770
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 23,
+                    "column": 9
+                },
+                "end": {
+                    "line": 23,
+                    "column": 10
+                }
+            },
+            "range": [
+                771,
+                772
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 4
+                },
+                "end": {
+                    "line": 24,
+                    "column": 7
+                }
+            },
+            "range": [
+                777,
+                780
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 8
+                },
+                "end": {
+                    "line": 24,
+                    "column": 15
+                }
+            },
+            "range": [
+                781,
+                788
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 16
+                },
+                "end": {
+                    "line": 24,
+                    "column": 17
+                }
+            },
+            "range": [
+                789,
+                790
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 18
+                },
+                "end": {
+                    "line": 24,
+                    "column": 32
+                }
+            },
+            "range": [
+                791,
+                805
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 32
+                },
+                "end": {
+                    "line": 24,
+                    "column": 33
+                }
+            },
+            "range": [
+                805,
+                806
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 4
+                },
+                "end": {
+                    "line": 25,
+                    "column": 10
+                }
+            },
+            "range": [
+                811,
+                817
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 11
+                },
+                "end": {
+                    "line": 25,
+                    "column": 12
+                }
+            },
+            "range": [
+                818,
+                819
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 13
+                },
+                "end": {
+                    "line": 25,
+                    "column": 20
+                }
+            },
+            "range": [
+                820,
+                827
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 20
+                },
+                "end": {
+                    "line": 25,
+                    "column": 21
+                }
+            },
+            "range": [
+                827,
+                828
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 26,
+                    "column": 2
+                },
+                "end": {
+                    "line": 26,
+                    "column": 3
+                }
+            },
+            "range": [
+                831,
+                832
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 0
+                },
+                "end": {
+                    "line": 27,
+                    "column": 1
+                }
+            },
+            "range": [
+                833,
+                834
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 0
+                },
+                "end": {
+                    "line": 29,
+                    "column": 6
+                }
+            },
+            "range": [
+                836,
+                842
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 6
+                },
+                "end": {
+                    "line": 29,
+                    "column": 7
+                }
+            },
+            "range": [
+                842,
+                843
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 7
+                },
+                "end": {
+                    "line": 29,
+                    "column": 16
+                }
+            },
+            "range": [
+                843,
+                852
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 16
+                },
+                "end": {
+                    "line": 29,
+                    "column": 17
+                }
+            },
+            "range": [
+                852,
+                853
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 17
+                },
+                "end": {
+                    "line": 29,
+                    "column": 24
+                }
+            },
+            "range": [
+                853,
+                860
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 24
+                },
+                "end": {
+                    "line": 29,
+                    "column": 25
+                }
+            },
+            "range": [
+                860,
+                861
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'outer scope'",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 26
+                },
+                "end": {
+                    "line": 29,
+                    "column": 39
+                }
+            },
+            "range": [
+                862,
+                875
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 39
+                },
+                "end": {
+                    "line": 29,
+                    "column": 40
+                }
+            },
+            "range": [
+                875,
+                876
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 40
+                },
+                "end": {
+                    "line": 29,
+                    "column": 41
+                }
+            },
+            "range": [
+                876,
+                877
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 0
+                },
+                "end": {
+                    "line": 30,
+                    "column": 6
+                }
+            },
+            "range": [
+                878,
+                884
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 6
+                },
+                "end": {
+                    "line": 30,
+                    "column": 7
+                }
+            },
+            "range": [
+                884,
+                885
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 7
+                },
+                "end": {
+                    "line": 30,
+                    "column": 16
+                }
+            },
+            "range": [
+                885,
+                894
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 16
+                },
+                "end": {
+                    "line": 30,
+                    "column": 17
+                }
+            },
+            "range": [
+                894,
+                895
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe1",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 17
+                },
+                "end": {
+                    "line": 30,
+                    "column": 23
+                }
+            },
+            "range": [
+                895,
+                901
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 23
+                },
+                "end": {
+                    "line": 30,
+                    "column": 24
+                }
+            },
+            "range": [
+                901,
+                902
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 25
+                },
+                "end": {
+                    "line": 30,
+                    "column": 38
+                }
+            },
+            "range": [
+                903,
+                916
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 38
+                },
+                "end": {
+                    "line": 30,
+                    "column": 39
+                }
+            },
+            "range": [
+                916,
+                917
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 39
+                },
+                "end": {
+                    "line": 30,
+                    "column": 40
+                }
+            },
+            "range": [
+                917,
+                918
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 0
+                },
+                "end": {
+                    "line": 31,
+                    "column": 6
+                }
+            },
+            "range": [
+                919,
+                925
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 6
+                },
+                "end": {
+                    "line": 31,
+                    "column": 7
+                }
+            },
+            "range": [
+                925,
+                926
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 7
+                },
+                "end": {
+                    "line": 31,
+                    "column": 16
+                }
+            },
+            "range": [
+                926,
+                935
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 16
+                },
+                "end": {
+                    "line": 31,
+                    "column": 17
+                }
+            },
+            "range": [
+                935,
+                936
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "probe2",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 17
+                },
+                "end": {
+                    "line": 31,
+                    "column": 23
+                }
+            },
+            "range": [
+                936,
+                942
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 23
+                },
+                "end": {
+                    "line": 31,
+                    "column": 24
+                }
+            },
+            "range": [
+                942,
+                943
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 25
+                },
+                "end": {
+                    "line": 31,
+                    "column": 39
+                }
+            },
+            "range": [
+                944,
+                958
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 39
+                },
+                "end": {
+                    "line": 31,
+                    "column": 40
+                }
+            },
+            "range": [
+                958,
+                959
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 40
+                },
+                "end": {
+                    "line": 31,
+                    "column": 41
+                }
+            },
+            "range": [
+                959,
+                960
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-open.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-scope-var-open.src.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: Creation of new environment record for variable-scoped bindings
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+    1. Let lex be the running execution context's LexicalEnvironment.
+    2. Let privateScope be the running execution context's PrivateEnvironment.
+    3. Let body be OrdinaryFunctionCreate(Method, « », ClassStaticBlockBody, lex, privateScope).
+features: [class-static-block]
+---*/
+
+var test262 = 'outer scope';
+var probe1, probe2;
+
+class C {
+  static {
+    var test262 = 'first block';
+    probe1 = test262;
+  }
+  static {
+    var test262 = 'second block';
+    probe2 = test262;
+  }
+}
+
+assert.sameValue(test262, 'outer scope');
+assert.sameValue(probe1, 'first block');
+assert.sameValue(probe2, 'second block');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-sequence.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-sequence.result.js
@@ -1,0 +1,3104 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 22,
+            "column": 0
+        },
+        "end": {
+            "line": 38,
+            "column": 46
+        }
+    },
+    "range": [
+        870,
+        1274
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 18
+                }
+            },
+            "range": [
+                870,
+                888
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 22,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 22,
+                            "column": 17
+                        }
+                    },
+                    "range": [
+                        874,
+                        887
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 22,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 12
+                            }
+                        },
+                        "range": [
+                            874,
+                            882
+                        ],
+                        "name": "sequence"
+                    },
+                    "init": {
+                        "type": "ArrayExpression",
+                        "loc": {
+                            "start": {
+                                "line": 22,
+                                "column": 15
+                            },
+                            "end": {
+                                "line": 22,
+                                "column": 17
+                            }
+                        },
+                        "range": [
+                            885,
+                            887
+                        ],
+                        "elements": []
+                    }
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 33,
+                    "column": 1
+                }
+            },
+            "range": [
+                890,
+                1087
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 24,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 24,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    896,
+                    897
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 24,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 33,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    898,
+                    1087
+                ],
+                "body": [
+                    {
+                        "type": "PropertyDefinition",
+                        "loc": {
+                            "start": {
+                                "line": 25,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 25,
+                                "column": 42
+                            }
+                        },
+                        "range": [
+                            902,
+                            942
+                        ],
+                        "static": true,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 25,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                909,
+                                910
+                            ],
+                            "name": "x"
+                        },
+                        "value": {
+                            "type": "CallExpression",
+                            "loc": {
+                                "start": {
+                                    "line": 25,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 25,
+                                    "column": 41
+                                }
+                            },
+                            "range": [
+                                913,
+                                941
+                            ],
+                            "callee": {
+                                "type": "MemberExpression",
+                                "loc": {
+                                    "start": {
+                                        "line": 25,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 25,
+                                        "column": 26
+                                    }
+                                },
+                                "range": [
+                                    913,
+                                    926
+                                ],
+                                "object": {
+                                    "type": "Identifier",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 13
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 21
+                                        }
+                                    },
+                                    "range": [
+                                        913,
+                                        921
+                                    ],
+                                    "name": "sequence"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 22
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 26
+                                        }
+                                    },
+                                    "range": [
+                                        922,
+                                        926
+                                    ],
+                                    "name": "push"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "arguments": [
+                                {
+                                    "type": "Literal",
+                                    "loc": {
+                                        "start": {
+                                            "line": 25,
+                                            "column": 27
+                                        },
+                                        "end": {
+                                            "line": 25,
+                                            "column": 40
+                                        }
+                                    },
+                                    "range": [
+                                        927,
+                                        940
+                                    ],
+                                    "value": "first field",
+                                    "raw": "'first field'"
+                                }
+                            ],
+                            "optional": false
+                        }
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 26,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 28,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            945,
+                            991
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 27,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 27,
+                                        "column": 33
+                                    }
+                                },
+                                "range": [
+                                    958,
+                                    987
+                                ],
+                                "expression": {
+                                    "type": "CallExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 27,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 27,
+                                            "column": 32
+                                        }
+                                    },
+                                    "range": [
+                                        958,
+                                        986
+                                    ],
+                                    "callee": {
+                                        "type": "MemberExpression",
+                                        "loc": {
+                                            "start": {
+                                                "line": 27,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 27,
+                                                "column": 17
+                                            }
+                                        },
+                                        "range": [
+                                            958,
+                                            971
+                                        ],
+                                        "object": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 27,
+                                                    "column": 4
+                                                },
+                                                "end": {
+                                                    "line": 27,
+                                                    "column": 12
+                                                }
+                                            },
+                                            "range": [
+                                                958,
+                                                966
+                                            ],
+                                            "name": "sequence"
+                                        },
+                                        "property": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 27,
+                                                    "column": 13
+                                                },
+                                                "end": {
+                                                    "line": 27,
+                                                    "column": 17
+                                                }
+                                            },
+                                            "range": [
+                                                967,
+                                                971
+                                            ],
+                                            "name": "push"
+                                        },
+                                        "computed": false,
+                                        "optional": false
+                                    },
+                                    "arguments": [
+                                        {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 27,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 27,
+                                                    "column": 31
+                                                }
+                                            },
+                                            "range": [
+                                                972,
+                                                985
+                                            ],
+                                            "value": "first block",
+                                            "raw": "'first block'"
+                                        }
+                                    ],
+                                    "optional": false
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "type": "PropertyDefinition",
+                        "loc": {
+                            "start": {
+                                "line": 29,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 29,
+                                "column": 43
+                            }
+                        },
+                        "range": [
+                            994,
+                            1035
+                        ],
+                        "static": true,
+                        "computed": false,
+                        "key": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 29,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 10
+                                }
+                            },
+                            "range": [
+                                1001,
+                                1002
+                            ],
+                            "name": "x"
+                        },
+                        "value": {
+                            "type": "CallExpression",
+                            "loc": {
+                                "start": {
+                                    "line": 29,
+                                    "column": 13
+                                },
+                                "end": {
+                                    "line": 29,
+                                    "column": 42
+                                }
+                            },
+                            "range": [
+                                1005,
+                                1034
+                            ],
+                            "callee": {
+                                "type": "MemberExpression",
+                                "loc": {
+                                    "start": {
+                                        "line": 29,
+                                        "column": 13
+                                    },
+                                    "end": {
+                                        "line": 29,
+                                        "column": 26
+                                    }
+                                },
+                                "range": [
+                                    1005,
+                                    1018
+                                ],
+                                "object": {
+                                    "type": "Identifier",
+                                    "loc": {
+                                        "start": {
+                                            "line": 29,
+                                            "column": 13
+                                        },
+                                        "end": {
+                                            "line": 29,
+                                            "column": 21
+                                        }
+                                    },
+                                    "range": [
+                                        1005,
+                                        1013
+                                    ],
+                                    "name": "sequence"
+                                },
+                                "property": {
+                                    "type": "Identifier",
+                                    "loc": {
+                                        "start": {
+                                            "line": 29,
+                                            "column": 22
+                                        },
+                                        "end": {
+                                            "line": 29,
+                                            "column": 26
+                                        }
+                                    },
+                                    "range": [
+                                        1014,
+                                        1018
+                                    ],
+                                    "name": "push"
+                                },
+                                "computed": false,
+                                "optional": false
+                            },
+                            "arguments": [
+                                {
+                                    "type": "Literal",
+                                    "loc": {
+                                        "start": {
+                                            "line": 29,
+                                            "column": 27
+                                        },
+                                        "end": {
+                                            "line": 29,
+                                            "column": 41
+                                        }
+                                    },
+                                    "range": [
+                                        1019,
+                                        1033
+                                    ],
+                                    "value": "second field",
+                                    "raw": "'second field'"
+                                }
+                            ],
+                            "optional": false
+                        }
+                    },
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 30,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 32,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            1038,
+                            1085
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 31,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 31,
+                                        "column": 34
+                                    }
+                                },
+                                "range": [
+                                    1051,
+                                    1081
+                                ],
+                                "expression": {
+                                    "type": "CallExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 31,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 31,
+                                            "column": 33
+                                        }
+                                    },
+                                    "range": [
+                                        1051,
+                                        1080
+                                    ],
+                                    "callee": {
+                                        "type": "MemberExpression",
+                                        "loc": {
+                                            "start": {
+                                                "line": 31,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 31,
+                                                "column": 17
+                                            }
+                                        },
+                                        "range": [
+                                            1051,
+                                            1064
+                                        ],
+                                        "object": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 31,
+                                                    "column": 4
+                                                },
+                                                "end": {
+                                                    "line": 31,
+                                                    "column": 12
+                                                }
+                                            },
+                                            "range": [
+                                                1051,
+                                                1059
+                                            ],
+                                            "name": "sequence"
+                                        },
+                                        "property": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 31,
+                                                    "column": 13
+                                                },
+                                                "end": {
+                                                    "line": 31,
+                                                    "column": 17
+                                                }
+                                            },
+                                            "range": [
+                                                1060,
+                                                1064
+                                            ],
+                                            "name": "push"
+                                        },
+                                        "computed": false,
+                                        "optional": false
+                                    },
+                                    "arguments": [
+                                        {
+                                            "type": "Literal",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 31,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 31,
+                                                    "column": 32
+                                                }
+                                            },
+                                            "range": [
+                                                1065,
+                                                1079
+                                            ],
+                                            "value": "second block",
+                                            "raw": "'second block'"
+                                        }
+                                    ],
+                                    "optional": false
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 0
+                },
+                "end": {
+                    "line": 35,
+                    "column": 45
+                }
+            },
+            "range": [
+                1089,
+                1134
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 35,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 35,
+                        "column": 44
+                    }
+                },
+                "range": [
+                    1089,
+                    1133
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 35,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 35,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        1089,
+                        1105
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 35,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 35,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            1089,
+                            1095
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 35,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 35,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            1096,
+                            1105
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "MemberExpression",
+                        "loc": {
+                            "start": {
+                                "line": 35,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 35,
+                                "column": 28
+                            }
+                        },
+                        "range": [
+                            1106,
+                            1117
+                        ],
+                        "object": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 35,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 35,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                1106,
+                                1114
+                            ],
+                            "name": "sequence"
+                        },
+                        "property": {
+                            "type": "Literal",
+                            "loc": {
+                                "start": {
+                                    "line": 35,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 35,
+                                    "column": 27
+                                }
+                            },
+                            "range": [
+                                1115,
+                                1116
+                            ],
+                            "value": 0,
+                            "raw": "0"
+                        },
+                        "computed": true,
+                        "optional": false
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 35,
+                                "column": 30
+                            },
+                            "end": {
+                                "line": 35,
+                                "column": 43
+                            }
+                        },
+                        "range": [
+                            1119,
+                            1132
+                        ],
+                        "value": "first field",
+                        "raw": "'first field'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 0
+                },
+                "end": {
+                    "line": 36,
+                    "column": 45
+                }
+            },
+            "range": [
+                1135,
+                1180
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 36,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 36,
+                        "column": 44
+                    }
+                },
+                "range": [
+                    1135,
+                    1179
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 36,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 36,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        1135,
+                        1151
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 36,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            1135,
+                            1141
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 36,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            1142,
+                            1151
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "MemberExpression",
+                        "loc": {
+                            "start": {
+                                "line": 36,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 28
+                            }
+                        },
+                        "range": [
+                            1152,
+                            1163
+                        ],
+                        "object": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 36,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                1152,
+                                1160
+                            ],
+                            "name": "sequence"
+                        },
+                        "property": {
+                            "type": "Literal",
+                            "loc": {
+                                "start": {
+                                    "line": 36,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 36,
+                                    "column": 27
+                                }
+                            },
+                            "range": [
+                                1161,
+                                1162
+                            ],
+                            "value": 1,
+                            "raw": "1"
+                        },
+                        "computed": true,
+                        "optional": false
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 36,
+                                "column": 30
+                            },
+                            "end": {
+                                "line": 36,
+                                "column": 43
+                            }
+                        },
+                        "range": [
+                            1165,
+                            1178
+                        ],
+                        "value": "first block",
+                        "raw": "'first block'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 0
+                },
+                "end": {
+                    "line": 37,
+                    "column": 46
+                }
+            },
+            "range": [
+                1181,
+                1227
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 37,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 37,
+                        "column": 45
+                    }
+                },
+                "range": [
+                    1181,
+                    1226
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 37,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 37,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        1181,
+                        1197
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 37,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            1181,
+                            1187
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 37,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            1188,
+                            1197
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "MemberExpression",
+                        "loc": {
+                            "start": {
+                                "line": 37,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 28
+                            }
+                        },
+                        "range": [
+                            1198,
+                            1209
+                        ],
+                        "object": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 37,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                1198,
+                                1206
+                            ],
+                            "name": "sequence"
+                        },
+                        "property": {
+                            "type": "Literal",
+                            "loc": {
+                                "start": {
+                                    "line": 37,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 37,
+                                    "column": 27
+                                }
+                            },
+                            "range": [
+                                1207,
+                                1208
+                            ],
+                            "value": 2,
+                            "raw": "2"
+                        },
+                        "computed": true,
+                        "optional": false
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 37,
+                                "column": 30
+                            },
+                            "end": {
+                                "line": 37,
+                                "column": 44
+                            }
+                        },
+                        "range": [
+                            1211,
+                            1225
+                        ],
+                        "value": "second field",
+                        "raw": "'second field'"
+                    }
+                ],
+                "optional": false
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 0
+                },
+                "end": {
+                    "line": 38,
+                    "column": 46
+                }
+            },
+            "range": [
+                1228,
+                1274
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 38,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 38,
+                        "column": 45
+                    }
+                },
+                "range": [
+                    1228,
+                    1273
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 38,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 38,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        1228,
+                        1244
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 38,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            1228,
+                            1234
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 38,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            1235,
+                            1244
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "MemberExpression",
+                        "loc": {
+                            "start": {
+                                "line": 38,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 28
+                            }
+                        },
+                        "range": [
+                            1245,
+                            1256
+                        ],
+                        "object": {
+                            "type": "Identifier",
+                            "loc": {
+                                "start": {
+                                    "line": 38,
+                                    "column": 17
+                                },
+                                "end": {
+                                    "line": 38,
+                                    "column": 25
+                                }
+                            },
+                            "range": [
+                                1245,
+                                1253
+                            ],
+                            "name": "sequence"
+                        },
+                        "property": {
+                            "type": "Literal",
+                            "loc": {
+                                "start": {
+                                    "line": 38,
+                                    "column": 26
+                                },
+                                "end": {
+                                    "line": 38,
+                                    "column": 27
+                                }
+                            },
+                            "range": [
+                                1254,
+                                1255
+                            ],
+                            "value": 3,
+                            "raw": "3"
+                        },
+                        "computed": true,
+                        "optional": false
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 38,
+                                "column": 30
+                            },
+                            "end": {
+                                "line": 38,
+                                "column": 44
+                            }
+                        },
+                        "range": [
+                            1258,
+                            1272
+                        ],
+                        "value": "second block",
+                        "raw": "'second block'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 3
+                }
+            },
+            "range": [
+                870,
+                873
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 4
+                },
+                "end": {
+                    "line": 22,
+                    "column": 12
+                }
+            },
+            "range": [
+                874,
+                882
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 13
+                },
+                "end": {
+                    "line": 22,
+                    "column": 14
+                }
+            },
+            "range": [
+                883,
+                884
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 15
+                },
+                "end": {
+                    "line": 22,
+                    "column": 16
+                }
+            },
+            "range": [
+                885,
+                886
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 16
+                },
+                "end": {
+                    "line": 22,
+                    "column": 17
+                }
+            },
+            "range": [
+                886,
+                887
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 17
+                },
+                "end": {
+                    "line": 22,
+                    "column": 18
+                }
+            },
+            "range": [
+                887,
+                888
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 24,
+                    "column": 5
+                }
+            },
+            "range": [
+                890,
+                895
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 6
+                },
+                "end": {
+                    "line": 24,
+                    "column": 7
+                }
+            },
+            "range": [
+                896,
+                897
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 8
+                },
+                "end": {
+                    "line": 24,
+                    "column": 9
+                }
+            },
+            "range": [
+                898,
+                899
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 2
+                },
+                "end": {
+                    "line": 25,
+                    "column": 8
+                }
+            },
+            "range": [
+                902,
+                908
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "x",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 9
+                },
+                "end": {
+                    "line": 25,
+                    "column": 10
+                }
+            },
+            "range": [
+                909,
+                910
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 11
+                },
+                "end": {
+                    "line": 25,
+                    "column": 12
+                }
+            },
+            "range": [
+                911,
+                912
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 13
+                },
+                "end": {
+                    "line": 25,
+                    "column": 21
+                }
+            },
+            "range": [
+                913,
+                921
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 21
+                },
+                "end": {
+                    "line": 25,
+                    "column": 22
+                }
+            },
+            "range": [
+                921,
+                922
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "push",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 22
+                },
+                "end": {
+                    "line": 25,
+                    "column": 26
+                }
+            },
+            "range": [
+                922,
+                926
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 26
+                },
+                "end": {
+                    "line": 25,
+                    "column": 27
+                }
+            },
+            "range": [
+                926,
+                927
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first field'",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 27
+                },
+                "end": {
+                    "line": 25,
+                    "column": 40
+                }
+            },
+            "range": [
+                927,
+                940
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 40
+                },
+                "end": {
+                    "line": 25,
+                    "column": 41
+                }
+            },
+            "range": [
+                940,
+                941
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 25,
+                    "column": 41
+                },
+                "end": {
+                    "line": 25,
+                    "column": 42
+                }
+            },
+            "range": [
+                941,
+                942
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 26,
+                    "column": 2
+                },
+                "end": {
+                    "line": 26,
+                    "column": 8
+                }
+            },
+            "range": [
+                945,
+                951
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 26,
+                    "column": 9
+                },
+                "end": {
+                    "line": 26,
+                    "column": 10
+                }
+            },
+            "range": [
+                952,
+                953
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 4
+                },
+                "end": {
+                    "line": 27,
+                    "column": 12
+                }
+            },
+            "range": [
+                958,
+                966
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 12
+                },
+                "end": {
+                    "line": 27,
+                    "column": 13
+                }
+            },
+            "range": [
+                966,
+                967
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "push",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 13
+                },
+                "end": {
+                    "line": 27,
+                    "column": 17
+                }
+            },
+            "range": [
+                967,
+                971
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 17
+                },
+                "end": {
+                    "line": 27,
+                    "column": 18
+                }
+            },
+            "range": [
+                971,
+                972
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 18
+                },
+                "end": {
+                    "line": 27,
+                    "column": 31
+                }
+            },
+            "range": [
+                972,
+                985
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 31
+                },
+                "end": {
+                    "line": 27,
+                    "column": 32
+                }
+            },
+            "range": [
+                985,
+                986
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 27,
+                    "column": 32
+                },
+                "end": {
+                    "line": 27,
+                    "column": 33
+                }
+            },
+            "range": [
+                986,
+                987
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 28,
+                    "column": 2
+                },
+                "end": {
+                    "line": 28,
+                    "column": 3
+                }
+            },
+            "range": [
+                990,
+                991
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 2
+                },
+                "end": {
+                    "line": 29,
+                    "column": 8
+                }
+            },
+            "range": [
+                994,
+                1000
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "x",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 9
+                },
+                "end": {
+                    "line": 29,
+                    "column": 10
+                }
+            },
+            "range": [
+                1001,
+                1002
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 11
+                },
+                "end": {
+                    "line": 29,
+                    "column": 12
+                }
+            },
+            "range": [
+                1003,
+                1004
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 13
+                },
+                "end": {
+                    "line": 29,
+                    "column": 21
+                }
+            },
+            "range": [
+                1005,
+                1013
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 21
+                },
+                "end": {
+                    "line": 29,
+                    "column": 22
+                }
+            },
+            "range": [
+                1013,
+                1014
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "push",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 22
+                },
+                "end": {
+                    "line": 29,
+                    "column": 26
+                }
+            },
+            "range": [
+                1014,
+                1018
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 26
+                },
+                "end": {
+                    "line": 29,
+                    "column": 27
+                }
+            },
+            "range": [
+                1018,
+                1019
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second field'",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 27
+                },
+                "end": {
+                    "line": 29,
+                    "column": 41
+                }
+            },
+            "range": [
+                1019,
+                1033
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 41
+                },
+                "end": {
+                    "line": 29,
+                    "column": 42
+                }
+            },
+            "range": [
+                1033,
+                1034
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 29,
+                    "column": 42
+                },
+                "end": {
+                    "line": 29,
+                    "column": 43
+                }
+            },
+            "range": [
+                1034,
+                1035
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 2
+                },
+                "end": {
+                    "line": 30,
+                    "column": 8
+                }
+            },
+            "range": [
+                1038,
+                1044
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 30,
+                    "column": 9
+                },
+                "end": {
+                    "line": 30,
+                    "column": 10
+                }
+            },
+            "range": [
+                1045,
+                1046
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 4
+                },
+                "end": {
+                    "line": 31,
+                    "column": 12
+                }
+            },
+            "range": [
+                1051,
+                1059
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 12
+                },
+                "end": {
+                    "line": 31,
+                    "column": 13
+                }
+            },
+            "range": [
+                1059,
+                1060
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "push",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 13
+                },
+                "end": {
+                    "line": 31,
+                    "column": 17
+                }
+            },
+            "range": [
+                1060,
+                1064
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 17
+                },
+                "end": {
+                    "line": 31,
+                    "column": 18
+                }
+            },
+            "range": [
+                1064,
+                1065
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 18
+                },
+                "end": {
+                    "line": 31,
+                    "column": 32
+                }
+            },
+            "range": [
+                1065,
+                1079
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 32
+                },
+                "end": {
+                    "line": 31,
+                    "column": 33
+                }
+            },
+            "range": [
+                1079,
+                1080
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 31,
+                    "column": 33
+                },
+                "end": {
+                    "line": 31,
+                    "column": 34
+                }
+            },
+            "range": [
+                1080,
+                1081
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 32,
+                    "column": 2
+                },
+                "end": {
+                    "line": 32,
+                    "column": 3
+                }
+            },
+            "range": [
+                1084,
+                1085
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 33,
+                    "column": 0
+                },
+                "end": {
+                    "line": 33,
+                    "column": 1
+                }
+            },
+            "range": [
+                1086,
+                1087
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 0
+                },
+                "end": {
+                    "line": 35,
+                    "column": 6
+                }
+            },
+            "range": [
+                1089,
+                1095
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 6
+                },
+                "end": {
+                    "line": 35,
+                    "column": 7
+                }
+            },
+            "range": [
+                1095,
+                1096
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 7
+                },
+                "end": {
+                    "line": 35,
+                    "column": 16
+                }
+            },
+            "range": [
+                1096,
+                1105
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 16
+                },
+                "end": {
+                    "line": 35,
+                    "column": 17
+                }
+            },
+            "range": [
+                1105,
+                1106
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 17
+                },
+                "end": {
+                    "line": 35,
+                    "column": 25
+                }
+            },
+            "range": [
+                1106,
+                1114
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 25
+                },
+                "end": {
+                    "line": 35,
+                    "column": 26
+                }
+            },
+            "range": [
+                1114,
+                1115
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "0",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 26
+                },
+                "end": {
+                    "line": 35,
+                    "column": 27
+                }
+            },
+            "range": [
+                1115,
+                1116
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 27
+                },
+                "end": {
+                    "line": 35,
+                    "column": 28
+                }
+            },
+            "range": [
+                1116,
+                1117
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 28
+                },
+                "end": {
+                    "line": 35,
+                    "column": 29
+                }
+            },
+            "range": [
+                1117,
+                1118
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first field'",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 30
+                },
+                "end": {
+                    "line": 35,
+                    "column": 43
+                }
+            },
+            "range": [
+                1119,
+                1132
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 43
+                },
+                "end": {
+                    "line": 35,
+                    "column": 44
+                }
+            },
+            "range": [
+                1132,
+                1133
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 35,
+                    "column": 44
+                },
+                "end": {
+                    "line": 35,
+                    "column": 45
+                }
+            },
+            "range": [
+                1133,
+                1134
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 0
+                },
+                "end": {
+                    "line": 36,
+                    "column": 6
+                }
+            },
+            "range": [
+                1135,
+                1141
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 6
+                },
+                "end": {
+                    "line": 36,
+                    "column": 7
+                }
+            },
+            "range": [
+                1141,
+                1142
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 7
+                },
+                "end": {
+                    "line": 36,
+                    "column": 16
+                }
+            },
+            "range": [
+                1142,
+                1151
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 16
+                },
+                "end": {
+                    "line": 36,
+                    "column": 17
+                }
+            },
+            "range": [
+                1151,
+                1152
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 17
+                },
+                "end": {
+                    "line": 36,
+                    "column": 25
+                }
+            },
+            "range": [
+                1152,
+                1160
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 25
+                },
+                "end": {
+                    "line": 36,
+                    "column": 26
+                }
+            },
+            "range": [
+                1160,
+                1161
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "1",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 26
+                },
+                "end": {
+                    "line": 36,
+                    "column": 27
+                }
+            },
+            "range": [
+                1161,
+                1162
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 27
+                },
+                "end": {
+                    "line": 36,
+                    "column": 28
+                }
+            },
+            "range": [
+                1162,
+                1163
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 28
+                },
+                "end": {
+                    "line": 36,
+                    "column": 29
+                }
+            },
+            "range": [
+                1163,
+                1164
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'first block'",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 30
+                },
+                "end": {
+                    "line": 36,
+                    "column": 43
+                }
+            },
+            "range": [
+                1165,
+                1178
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 43
+                },
+                "end": {
+                    "line": 36,
+                    "column": 44
+                }
+            },
+            "range": [
+                1178,
+                1179
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 36,
+                    "column": 44
+                },
+                "end": {
+                    "line": 36,
+                    "column": 45
+                }
+            },
+            "range": [
+                1179,
+                1180
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 0
+                },
+                "end": {
+                    "line": 37,
+                    "column": 6
+                }
+            },
+            "range": [
+                1181,
+                1187
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 6
+                },
+                "end": {
+                    "line": 37,
+                    "column": 7
+                }
+            },
+            "range": [
+                1187,
+                1188
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 7
+                },
+                "end": {
+                    "line": 37,
+                    "column": 16
+                }
+            },
+            "range": [
+                1188,
+                1197
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 16
+                },
+                "end": {
+                    "line": 37,
+                    "column": 17
+                }
+            },
+            "range": [
+                1197,
+                1198
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 17
+                },
+                "end": {
+                    "line": 37,
+                    "column": 25
+                }
+            },
+            "range": [
+                1198,
+                1206
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 25
+                },
+                "end": {
+                    "line": 37,
+                    "column": 26
+                }
+            },
+            "range": [
+                1206,
+                1207
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "2",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 26
+                },
+                "end": {
+                    "line": 37,
+                    "column": 27
+                }
+            },
+            "range": [
+                1207,
+                1208
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 27
+                },
+                "end": {
+                    "line": 37,
+                    "column": 28
+                }
+            },
+            "range": [
+                1208,
+                1209
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 28
+                },
+                "end": {
+                    "line": 37,
+                    "column": 29
+                }
+            },
+            "range": [
+                1209,
+                1210
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second field'",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 30
+                },
+                "end": {
+                    "line": 37,
+                    "column": 44
+                }
+            },
+            "range": [
+                1211,
+                1225
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 44
+                },
+                "end": {
+                    "line": 37,
+                    "column": 45
+                }
+            },
+            "range": [
+                1225,
+                1226
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 37,
+                    "column": 45
+                },
+                "end": {
+                    "line": 37,
+                    "column": 46
+                }
+            },
+            "range": [
+                1226,
+                1227
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 0
+                },
+                "end": {
+                    "line": 38,
+                    "column": 6
+                }
+            },
+            "range": [
+                1228,
+                1234
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 6
+                },
+                "end": {
+                    "line": 38,
+                    "column": 7
+                }
+            },
+            "range": [
+                1234,
+                1235
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 7
+                },
+                "end": {
+                    "line": 38,
+                    "column": 16
+                }
+            },
+            "range": [
+                1235,
+                1244
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 16
+                },
+                "end": {
+                    "line": 38,
+                    "column": 17
+                }
+            },
+            "range": [
+                1244,
+                1245
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sequence",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 17
+                },
+                "end": {
+                    "line": 38,
+                    "column": 25
+                }
+            },
+            "range": [
+                1245,
+                1253
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 25
+                },
+                "end": {
+                    "line": 38,
+                    "column": 26
+                }
+            },
+            "range": [
+                1253,
+                1254
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "3",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 26
+                },
+                "end": {
+                    "line": 38,
+                    "column": 27
+                }
+            },
+            "range": [
+                1254,
+                1255
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 27
+                },
+                "end": {
+                    "line": 38,
+                    "column": 28
+                }
+            },
+            "range": [
+                1255,
+                1256
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 28
+                },
+                "end": {
+                    "line": 38,
+                    "column": 29
+                }
+            },
+            "range": [
+                1256,
+                1257
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'second block'",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 30
+                },
+                "end": {
+                    "line": 38,
+                    "column": 44
+                }
+            },
+            "range": [
+                1258,
+                1272
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 44
+                },
+                "end": {
+                    "line": 38,
+                    "column": 45
+                }
+            },
+            "range": [
+                1272,
+                1273
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 38,
+                    "column": 45
+                },
+                "end": {
+                    "line": 38,
+                    "column": 46
+                }
+            },
+            "range": [
+                1273,
+                1274
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-sequence.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-sequence.src.js
@@ -1,0 +1,38 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classelementevaluation
+description: Static blocks are evaluated in the order they appear in the source text, interleaved with static fields
+info: |
+  5.1.14 Runtime Semantics: ClassDefinitionEvaluation
+
+  [...]
+  34. For each element elementRecord of staticElements in List order, do
+    a. If elementRecord is a ClassFieldDefinition Record, then
+        i. Let status be the result of performing DefineField(F,
+        elementRecord).
+    b. Else,
+        i. Assert: fieldRecord is a ClassStaticBlockDefinition Record.
+        ii. Let status be the result of performing EvaluateStaticBlock(F,
+            elementRecord).
+    [...]
+features: [class-static-fields-public, class-static-block]
+---*/
+
+var sequence = [];
+
+class C {
+  static x = sequence.push('first field');
+  static {
+    sequence.push('first block');
+  }
+  static x = sequence.push('second field');
+  static {
+    sequence.push('second block');
+  }
+}
+
+assert.sameValue(sequence[0], 'first field');
+assert.sameValue(sequence[1], 'first block');
+assert.sameValue(sequence[2], 'second field');
+assert.sameValue(sequence[3], 'second block');

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-statement-list-optional.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-statement-list-optional.result.js
@@ -1,0 +1,221 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 16,
+            "column": 0
+        },
+        "end": {
+            "line": 18,
+            "column": 1
+        }
+    },
+    "range": [
+        370,
+        393
+    ],
+    "body": [
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 1
+                }
+            },
+            "range": [
+                370,
+                393
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 16,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 16,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    376,
+                    377
+                ],
+                "name": "C"
+            },
+            "superClass": null,
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 16,
+                        "column": 8
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    378,
+                    393
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 17,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 17,
+                                "column": 11
+                            }
+                        },
+                        "range": [
+                            382,
+                            391
+                        ],
+                        "body": []
+                    }
+                ]
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 5
+                }
+            },
+            "range": [
+                370,
+                375
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 6
+                },
+                "end": {
+                    "line": 16,
+                    "column": 7
+                }
+            },
+            "range": [
+                376,
+                377
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 8
+                },
+                "end": {
+                    "line": 16,
+                    "column": 9
+                }
+            },
+            "range": [
+                378,
+                379
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 2
+                },
+                "end": {
+                    "line": 17,
+                    "column": 8
+                }
+            },
+            "range": [
+                382,
+                388
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 9
+                },
+                "end": {
+                    "line": 17,
+                    "column": 10
+                }
+            },
+            "range": [
+                389,
+                390
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 17,
+                    "column": 10
+                },
+                "end": {
+                    "line": 17,
+                    "column": 11
+                }
+            },
+            "range": [
+                390,
+                391
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 1
+                }
+            },
+            "range": [
+                392,
+                393
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-statement-list-optional.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-statement-list-optional.src.js
@@ -1,0 +1,18 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-class-definitions
+description: The block's statement list is optional
+info: |
+  Syntax
+
+  [...]
+
+  ClassStaticBlockStatementList :
+     StatementList[~Yield, +Await, ~Return]opt
+features: [class-static-block]
+---*/
+
+class C {
+  static {}
+}

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-super-property.result.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-super-property.result.js
@@ -1,0 +1,1273 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 14,
+            "column": 0
+        },
+        "end": {
+            "line": 24,
+            "column": 35
+        }
+    },
+    "range": [
+        449,
+        615
+    ],
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 20
+                }
+            },
+            "range": [
+                449,
+                469
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 14,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 15
+                    }
+                },
+                "range": [
+                    458,
+                    464
+                ],
+                "name": "Parent"
+            },
+            "expression": false,
+            "generator": false,
+            "async": false,
+            "params": [],
+            "body": {
+                "type": "BlockStatement",
+                "loc": {
+                    "start": {
+                        "line": 14,
+                        "column": 18
+                    },
+                    "end": {
+                        "line": 14,
+                        "column": 20
+                    }
+                },
+                "range": [
+                    467,
+                    469
+                ],
+                "body": []
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                470,
+                497
+            ],
+            "expression": {
+                "type": "AssignmentExpression",
+                "loc": {
+                    "start": {
+                        "line": 15,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 15,
+                        "column": 26
+                    }
+                },
+                "range": [
+                    470,
+                    496
+                ],
+                "operator": "=",
+                "left": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 14
+                        }
+                    },
+                    "range": [
+                        470,
+                        484
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            470,
+                            476
+                        ],
+                        "name": "Parent"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 15,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 15,
+                                "column": 14
+                            }
+                        },
+                        "range": [
+                            477,
+                            484
+                        ],
+                        "name": "test262"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "right": {
+                    "type": "Literal",
+                    "loc": {
+                        "start": {
+                            "line": 15,
+                            "column": 17
+                        },
+                        "end": {
+                            "line": 15,
+                            "column": 26
+                        }
+                    },
+                    "range": [
+                        487,
+                        496
+                    ],
+                    "value": "test262",
+                    "raw": "'test262'"
+                }
+            }
+        },
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                498,
+                508
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 16,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 16,
+                            "column": 9
+                        }
+                    },
+                    "range": [
+                        502,
+                        507
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 16,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 16,
+                                "column": 9
+                            }
+                        },
+                        "range": [
+                            502,
+                            507
+                        ],
+                        "name": "value"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "var"
+        },
+        {
+            "type": "ClassDeclaration",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 1
+                }
+            },
+            "range": [
+                510,
+                578
+            ],
+            "id": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 6
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 7
+                    }
+                },
+                "range": [
+                    516,
+                    517
+                ],
+                "name": "C"
+            },
+            "superClass": {
+                "type": "Identifier",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 16
+                    },
+                    "end": {
+                        "line": 18,
+                        "column": 22
+                    }
+                },
+                "range": [
+                    526,
+                    532
+                ],
+                "name": "Parent"
+            },
+            "body": {
+                "type": "ClassBody",
+                "loc": {
+                    "start": {
+                        "line": 18,
+                        "column": 23
+                    },
+                    "end": {
+                        "line": 22,
+                        "column": 1
+                    }
+                },
+                "range": [
+                    533,
+                    578
+                ],
+                "body": [
+                    {
+                        "type": "StaticBlock",
+                        "loc": {
+                            "start": {
+                                "line": 19,
+                                "column": 2
+                            },
+                            "end": {
+                                "line": 21,
+                                "column": 3
+                            }
+                        },
+                        "range": [
+                            537,
+                            576
+                        ],
+                        "body": [
+                            {
+                                "type": "ExpressionStatement",
+                                "loc": {
+                                    "start": {
+                                        "line": 20,
+                                        "column": 4
+                                    },
+                                    "end": {
+                                        "line": 20,
+                                        "column": 26
+                                    }
+                                },
+                                "range": [
+                                    550,
+                                    572
+                                ],
+                                "expression": {
+                                    "type": "AssignmentExpression",
+                                    "loc": {
+                                        "start": {
+                                            "line": 20,
+                                            "column": 4
+                                        },
+                                        "end": {
+                                            "line": 20,
+                                            "column": 25
+                                        }
+                                    },
+                                    "range": [
+                                        550,
+                                        571
+                                    ],
+                                    "operator": "=",
+                                    "left": {
+                                        "type": "Identifier",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 4
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 9
+                                            }
+                                        },
+                                        "range": [
+                                            550,
+                                            555
+                                        ],
+                                        "name": "value"
+                                    },
+                                    "right": {
+                                        "type": "MemberExpression",
+                                        "loc": {
+                                            "start": {
+                                                "line": 20,
+                                                "column": 12
+                                            },
+                                            "end": {
+                                                "line": 20,
+                                                "column": 25
+                                            }
+                                        },
+                                        "range": [
+                                            558,
+                                            571
+                                        ],
+                                        "object": {
+                                            "type": "Super",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 12
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 17
+                                                }
+                                            },
+                                            "range": [
+                                                558,
+                                                563
+                                            ]
+                                        },
+                                        "property": {
+                                            "type": "Identifier",
+                                            "loc": {
+                                                "start": {
+                                                    "line": 20,
+                                                    "column": 18
+                                                },
+                                                "end": {
+                                                    "line": 20,
+                                                    "column": 25
+                                                }
+                                            },
+                                            "range": [
+                                                564,
+                                                571
+                                            ],
+                                            "name": "test262"
+                                        },
+                                        "computed": false,
+                                        "optional": false
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
+            "type": "ExpressionStatement",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 24,
+                    "column": 35
+                }
+            },
+            "range": [
+                580,
+                615
+            ],
+            "expression": {
+                "type": "CallExpression",
+                "loc": {
+                    "start": {
+                        "line": 24,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 24,
+                        "column": 34
+                    }
+                },
+                "range": [
+                    580,
+                    614
+                ],
+                "callee": {
+                    "type": "MemberExpression",
+                    "loc": {
+                        "start": {
+                            "line": 24,
+                            "column": 0
+                        },
+                        "end": {
+                            "line": 24,
+                            "column": 16
+                        }
+                    },
+                    "range": [
+                        580,
+                        596
+                    ],
+                    "object": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 0
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 6
+                            }
+                        },
+                        "range": [
+                            580,
+                            586
+                        ],
+                        "name": "assert"
+                    },
+                    "property": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 7
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 16
+                            }
+                        },
+                        "range": [
+                            587,
+                            596
+                        ],
+                        "name": "sameValue"
+                    },
+                    "computed": false,
+                    "optional": false
+                },
+                "arguments": [
+                    {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 17
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            597,
+                            602
+                        ],
+                        "name": "value"
+                    },
+                    {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 24,
+                                "column": 24
+                            },
+                            "end": {
+                                "line": 24,
+                                "column": 33
+                            }
+                        },
+                        "range": [
+                            604,
+                            613
+                        ],
+                        "value": "test262",
+                        "raw": "'test262'"
+                    }
+                ],
+                "optional": false
+            }
+        }
+    ],
+    "sourceType": "script",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 0
+                },
+                "end": {
+                    "line": 14,
+                    "column": 8
+                }
+            },
+            "range": [
+                449,
+                457
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Parent",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 9
+                },
+                "end": {
+                    "line": 14,
+                    "column": 15
+                }
+            },
+            "range": [
+                458,
+                464
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 15
+                },
+                "end": {
+                    "line": 14,
+                    "column": 16
+                }
+            },
+            "range": [
+                464,
+                465
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 16
+                },
+                "end": {
+                    "line": 14,
+                    "column": 17
+                }
+            },
+            "range": [
+                465,
+                466
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 18
+                },
+                "end": {
+                    "line": 14,
+                    "column": 19
+                }
+            },
+            "range": [
+                467,
+                468
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 14,
+                    "column": 19
+                },
+                "end": {
+                    "line": 14,
+                    "column": 20
+                }
+            },
+            "range": [
+                468,
+                469
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Parent",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 0
+                },
+                "end": {
+                    "line": 15,
+                    "column": 6
+                }
+            },
+            "range": [
+                470,
+                476
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 6
+                },
+                "end": {
+                    "line": 15,
+                    "column": 7
+                }
+            },
+            "range": [
+                476,
+                477
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 7
+                },
+                "end": {
+                    "line": 15,
+                    "column": 14
+                }
+            },
+            "range": [
+                477,
+                484
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 15
+                },
+                "end": {
+                    "line": 15,
+                    "column": 16
+                }
+            },
+            "range": [
+                485,
+                486
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'test262'",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 17
+                },
+                "end": {
+                    "line": 15,
+                    "column": 26
+                }
+            },
+            "range": [
+                487,
+                496
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 15,
+                    "column": 26
+                },
+                "end": {
+                    "line": 15,
+                    "column": 27
+                }
+            },
+            "range": [
+                496,
+                497
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "var",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 0
+                },
+                "end": {
+                    "line": 16,
+                    "column": 3
+                }
+            },
+            "range": [
+                498,
+                501
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 4
+                },
+                "end": {
+                    "line": 16,
+                    "column": 9
+                }
+            },
+            "range": [
+                502,
+                507
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 16,
+                    "column": 9
+                },
+                "end": {
+                    "line": 16,
+                    "column": 10
+                }
+            },
+            "range": [
+                507,
+                508
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "class",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 0
+                },
+                "end": {
+                    "line": 18,
+                    "column": 5
+                }
+            },
+            "range": [
+                510,
+                515
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "C",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 6
+                },
+                "end": {
+                    "line": 18,
+                    "column": 7
+                }
+            },
+            "range": [
+                516,
+                517
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "extends",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 8
+                },
+                "end": {
+                    "line": 18,
+                    "column": 15
+                }
+            },
+            "range": [
+                518,
+                525
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Parent",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 16
+                },
+                "end": {
+                    "line": 18,
+                    "column": 22
+                }
+            },
+            "range": [
+                526,
+                532
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 18,
+                    "column": 23
+                },
+                "end": {
+                    "line": 18,
+                    "column": 24
+                }
+            },
+            "range": [
+                533,
+                534
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "static",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 2
+                },
+                "end": {
+                    "line": 19,
+                    "column": 8
+                }
+            },
+            "range": [
+                537,
+                543
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 19,
+                    "column": 9
+                },
+                "end": {
+                    "line": 19,
+                    "column": 10
+                }
+            },
+            "range": [
+                544,
+                545
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 4
+                },
+                "end": {
+                    "line": 20,
+                    "column": 9
+                }
+            },
+            "range": [
+                550,
+                555
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 10
+                },
+                "end": {
+                    "line": 20,
+                    "column": 11
+                }
+            },
+            "range": [
+                556,
+                557
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "super",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 12
+                },
+                "end": {
+                    "line": 20,
+                    "column": 17
+                }
+            },
+            "range": [
+                558,
+                563
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 17
+                },
+                "end": {
+                    "line": 20,
+                    "column": 18
+                }
+            },
+            "range": [
+                563,
+                564
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "test262",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 18
+                },
+                "end": {
+                    "line": 20,
+                    "column": 25
+                }
+            },
+            "range": [
+                564,
+                571
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 20,
+                    "column": 25
+                },
+                "end": {
+                    "line": 20,
+                    "column": 26
+                }
+            },
+            "range": [
+                571,
+                572
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 21,
+                    "column": 2
+                },
+                "end": {
+                    "line": 21,
+                    "column": 3
+                }
+            },
+            "range": [
+                575,
+                576
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 22,
+                    "column": 0
+                },
+                "end": {
+                    "line": 22,
+                    "column": 1
+                }
+            },
+            "range": [
+                577,
+                578
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "assert",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 0
+                },
+                "end": {
+                    "line": 24,
+                    "column": 6
+                }
+            },
+            "range": [
+                580,
+                586
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ".",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 6
+                },
+                "end": {
+                    "line": 24,
+                    "column": 7
+                }
+            },
+            "range": [
+                586,
+                587
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "sameValue",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 7
+                },
+                "end": {
+                    "line": 24,
+                    "column": 16
+                }
+            },
+            "range": [
+                587,
+                596
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 16
+                },
+                "end": {
+                    "line": 24,
+                    "column": 17
+                }
+            },
+            "range": [
+                596,
+                597
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "value",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 17
+                },
+                "end": {
+                    "line": 24,
+                    "column": 22
+                }
+            },
+            "range": [
+                597,
+                602
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 22
+                },
+                "end": {
+                    "line": 24,
+                    "column": 23
+                }
+            },
+            "range": [
+                602,
+                603
+            ]
+        },
+        {
+            "type": "String",
+            "value": "'test262'",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 24
+                },
+                "end": {
+                    "line": 24,
+                    "column": 33
+                }
+            },
+            "range": [
+                604,
+                613
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 33
+                },
+                "end": {
+                    "line": 24,
+                    "column": 34
+                }
+            },
+            "range": [
+                613,
+                614
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 24,
+                    "column": 34
+                },
+                "end": {
+                    "line": 24,
+                    "column": 35
+                }
+            },
+            "range": [
+                614,
+                615
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-super-property.src.js
+++ b/tests/fixtures/ecma-version/13/class-static-blocks/statements-class-static-init-super-property.src.js
@@ -1,0 +1,24 @@
+// Copyright (C) 2021 the V8 project authors. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+/*---
+esid: sec-runtime-semantics-classstaticblockdefinitionevaluation
+description: The home object for a class static initialization block is the parent class
+info: |
+  ClassStaticBlock : static { ClassStaticBlockBody }
+
+  [...]
+  4. Perform MakeMethod(body, homeObject).
+features: [class-static-block]
+---*/
+
+function Parent() {}
+Parent.test262 = 'test262';
+var value;
+
+class C extends Parent {
+  static {
+    value = super.test262;
+  }
+}
+
+assert.sameValue(value, 'test262');


### PR DESCRIPTION
acorn has been upgraded in ee1d3eca310cab1b1cf1563294434977d26358d4, this commit simply added some tests. The tests were copied from test262, refs: https://github.com/tc39/test262/commit/afe217b318df5f197e64b30a8b5a4b391c777359
