### PR TITLE
build: upgrade eslint-release to v3.2.0 to support conventional commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-eslint": "^7.0.0",
     "eslint-plugin-jsdoc": "^32.2.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-release": "^3.1.2",
+    "eslint-release": "^3.2.0",
     "esprima": "latest",
     "esprima-fb": "^8001.2001.0-dev-harmony-fb",
     "json-diff": "^0.5.4",


### PR DESCRIPTION
Updates eslint-release dependency to the latest v3.2.0, which supports conventional commits.