### PR TITLE
feat: support class static blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Because ECMAScript 2022 is still under development, we are implementing features
 * [Class static fields, static private methods and accessors](https://github.com/tc39/proposal-static-class-features)
 * [RegExp match indices](https://github.com/tc39/proposal-regexp-match-indices)
 * [Top-level await](https://github.com/tc39/proposal-top-level-await)
+* [Class static initialization blocks](https://github.com/tc39/proposal-class-static-block)
 
 See [finished-proposals.md](https://github.com/tc39/proposals/blob/master/finished-proposals.md) to know what features are finalized.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "acorn": "^8.5.0",
     "acorn-jsx": "^5.3.1",
-    "eslint-visitor-keys": "^3.0.0"
+    "eslint-visitor-keys": "^3.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
This PR aims to complete support for class static blocks, by:

* Updating `eslint-visitor-keys` dependency to make sure that `StaticBlock` is included in the `VisitorKeys` export. We're not using `espree.VisitorKeys` in eslint packages (we're using `eslint-visitor-keys` directly), but other dependent packages may be relying on this export.
* Updating documentation.

Tests that confirm that parsing of class static blocks already works were added in https://github.com/eslint/espree/pull/515.

