### PR TITLE
feat: Add sourceType:commonjs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ const options = {
     // You can also set "latest" to use the most recently supported version.
     ecmaVersion: 5,
 
-    // specify which type of script you're parsing ("script" or "module")
+    // specify which type of script you're parsing ("script", "module", or "commonjs")
     sourceType: "script",
 
     // specify additional language features
@@ -154,7 +154,7 @@ const options = {
         // enable JSX parsing
         jsx: false,
 
-        // enable return in global scope
+        // enable return in global scope (set to true automatically when sourceType is "commonjs")
         globalReturn: false,
 
         // enable implied strict mode (if ecmaVersion >= 5)

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -100,10 +100,13 @@ export default () => Parser => {
                 }
             }, code);
 
-            this.originalSourceType = originalSourceType || options.sourceType;
-
-            // Initialize internal state.
+            /*
+             * Data that is unique to Espree and is not represented internally in
+             * Acorn. We put all of this data into a symbol property as a way to
+             * avoid potential naming conflicts with future versions of Acorn.
+             */
             this[STATE] = {
+                originalSourceType: originalSourceType || options.sourceType,
                 tokens: tokenTranslator ? [] : null,
                 comments: options.comment === true ? [] : null,
                 impliedStrict: ecmaFeatures.impliedStrict === true && this.options.ecmaVersion >= 5,
@@ -148,7 +151,7 @@ export default () => Parser => {
             const extra = this[STATE];
             const program = super.parse();
 
-            program.sourceType = this.originalSourceType;
+            program.sourceType = extra.originalSourceType;
 
             if (extra.comments) {
                 program.comments = extra.comments;

--- a/lib/espree.js
+++ b/lib/espree.js
@@ -56,6 +56,8 @@ export default () => Parser => {
                 code = String(code);
             }
 
+            // save original source type in case of commonjs
+            const originalSourceType = opts.sourceType;
             const options = normalizeOptions(opts);
             const ecmaFeatures = options.ecmaFeatures || {};
             const tokenTranslator =
@@ -74,7 +76,7 @@ export default () => Parser => {
                 allowReserved: options.allowReserved,
 
                 // Truthy value is true for backward compatibility.
-                allowReturnOutsideFunction: Boolean(ecmaFeatures.globalReturn),
+                allowReturnOutsideFunction: options.allowReturnOutsideFunction,
 
                 // Collect tokens
                 onToken: token => {
@@ -97,6 +99,8 @@ export default () => Parser => {
                     }
                 }
             }, code);
+
+            this.originalSourceType = originalSourceType || options.sourceType;
 
             // Initialize internal state.
             this[STATE] = {
@@ -144,7 +148,7 @@ export default () => Parser => {
             const extra = this[STATE];
             const program = super.parse();
 
-            program.sourceType = this.options.sourceType;
+            program.sourceType = this.originalSourceType;
 
             if (extra.comments) {
                 program.comments = extra.comments;

--- a/lib/options.js
+++ b/lib/options.js
@@ -73,6 +73,11 @@ function normalizeSourceType(sourceType = "script") {
     if (sourceType === "script" || sourceType === "module") {
         return sourceType;
     }
+
+    if (sourceType === "commonjs") {
+        return "script";
+    }
+
     throw new Error("Invalid sourceType.");
 }
 
@@ -88,15 +93,20 @@ export function normalizeOptions(options) {
     const ranges = options.range === true;
     const locations = options.loc === true;
     const allowReserved = ecmaVersion === 3 ? "never" : false;
+    const ecmaFeatures = options.ecmaFeatures || {};
+    const allowReturnOutsideFunction = options.sourceType === "commonjs" ||
+        Boolean(ecmaFeatures.globalReturn);
 
     if (sourceType === "module" && ecmaVersion < 6) {
         throw new Error("sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.");
     }
+
     return Object.assign({}, options, {
         ecmaVersion,
         sourceType,
         ranges,
         locations,
-        allowReserved
+        allowReserved,
+        allowReturnOutsideFunction
     });
 }

--- a/tests/lib/parse.js
+++ b/tests/lib/parse.js
@@ -41,15 +41,32 @@ describe("parse()", () => {
 
     });
 
-    describe("modules", () => {
+    describe("sourceType", () => {
 
-        it("should have correct column number when strict mode error occurs", () => {
+        describe("module", () => {
 
-            try {
-                espree.parse("function fn(a, a) {\n}", { ecmaVersion: 6, sourceType: "module" });
-            } catch (err) {
-                assert.strictEqual(err.column, 16);
-            }
+            it("should have correct column number when strict mode error occurs", () => {
+
+                try {
+                    espree.parse("function fn(a, a) {\n}", { ecmaVersion: 6, sourceType: "module" });
+                } catch (err) {
+                    assert.strictEqual(err.column, 16);
+                }
+            });
+
+        });
+
+        describe("commonjs", () => {
+
+            it("should parse top-level return", () => {
+                espree.parse("return;", { sourceType: "commonjs" });
+            });
+
+            it("should have sourceType:commonjs on Program node", () => {
+                const result = espree.parse("return;", { sourceType: "commonjs" });
+
+                assert.strictEqual(result.sourceType, "commonjs");
+            });
         });
 
     });


### PR DESCRIPTION
Adds support for setting `sourceType: commonjs`. This causes the `globalReturn` flag to be set to `true` and changes `sourceType` on the `Program` node to be `"commonjs"`.

Related: https://github.com/eslint/eslint-scope/pull/81

Fixes #519