### PR TITLE
docs: add private-in syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ const options = {
     // create a top-level tokens array containing all tokens
     tokens: false,
 
-    // Set to 3, 5 (the default), 6, 7, 8, 9, 10, 11, or 12 to specify the version of ECMAScript syntax you want to use.
+    // Set to 3, 5 (the default), 6, 7, 8, 9, 10, 11, 12, or 13 to specify the version of ECMAScript syntax you want to use.
     // You can also set to 2015 (same as 6), 2016 (same as 7), 2017 (same as 8), 2018 (same as 9), 2019 (same as 10), 2020 (same as 11), 2021 (same as 12), or 2022 (same as 13) to use the year-based naming.
     // You can also set "latest" to use the most recently supported version.
     ecmaVersion: 5,
@@ -239,6 +239,7 @@ Because ECMAScript 2022 is still under development, we are implementing features
 * [RegExp match indices](https://github.com/tc39/proposal-regexp-match-indices)
 * [Top-level await](https://github.com/tc39/proposal-top-level-await)
 * [Class static initialization blocks](https://github.com/tc39/proposal-class-static-block)
+* [Ergonomic brand checks for Private Fields](https://github.com/tc39/proposal-private-fields-in-in)
 
 See [finished-proposals.md](https://github.com/tc39/proposals/blob/master/finished-proposals.md) to know what features are finalized.
 


### PR DESCRIPTION
This PR documents that Espree supports private-in syntax (Ergonomic brand checks for Private Fields).