### PR TITLE
feat: support arbitrary module namespace names

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "BSD-2-Clause",
   "dependencies": {
-    "acorn": "^8.6.0",
+    "acorn": "^8.7.0",
     "acorn-jsx": "^5.3.1",
     "eslint-visitor-keys": "^3.1.0"
   },

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-all-exported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-all-exported.result.js
@@ -1,0 +1,203 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 30
+        }
+    },
+    "range": [
+        0,
+        30
+    ],
+    "body": [
+        {
+            "type": "ExportAllDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                0,
+                30
+            ],
+            "exported": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 12
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 18
+                    }
+                },
+                "range": [
+                    12,
+                    18
+                ],
+                "value": " 👶 ",
+                "raw": "\" 👶 \""
+            },
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 24
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 29
+                    }
+                },
+                "range": [
+                    24,
+                    29
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "*",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 11
+                }
+            },
+            "range": [
+                9,
+                11
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 12
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "range": [
+                12,
+                18
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 23
+                }
+            },
+            "range": [
+                19,
+                23
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 24
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                24,
+                29
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                29,
+                30
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-all-exported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-all-exported.src.js
@@ -1,0 +1,1 @@
+export * as " 👶 " from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported-with-escapes.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported-with-escapes.result.js
@@ -1,0 +1,333 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 35
+        }
+    },
+    "range": [
+        0,
+        44
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 7
+                        }
+                    },
+                    "range": [
+                        4,
+                        7
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 7
+                            }
+                        },
+                        "range": [
+                            4,
+                            7
+                        ],
+                        "name": "foo"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "let"
+        },
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 35
+                }
+            },
+            "range": [
+                9,
+                44
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 32
+                        }
+                    },
+                    "range": [
+                        18,
+                        41
+                    ],
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 12
+                            }
+                        },
+                        "range": [
+                            18,
+                            21
+                        ],
+                        "name": "foo"
+                    },
+                    "exported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 16
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 32
+                            }
+                        },
+                        "range": [
+                            25,
+                            41
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" \\uD83D\\uDC76 \""
+                    }
+                }
+            ],
+            "source": null
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                3
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "range": [
+                4,
+                7
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 6
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            },
+            "range": [
+                18,
+                21
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            },
+            "range": [
+                22,
+                24
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" \\uD83D\\uDC76 \"",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 32
+                }
+            },
+            "range": [
+                25,
+                41
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 33
+                },
+                "end": {
+                    "line": 2,
+                    "column": 34
+                }
+            },
+            "range": [
+                42,
+                43
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 34
+                },
+                "end": {
+                    "line": 2,
+                    "column": 35
+                }
+            },
+            "range": [
+                43,
+                44
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported-with-escapes.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported-with-escapes.src.js
@@ -1,0 +1,2 @@
+let foo;
+export { foo as " \uD83D\uDC76 " };

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported.result.js
@@ -1,0 +1,333 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 25
+        }
+    },
+    "range": [
+        0,
+        34
+    ],
+    "body": [
+        {
+            "type": "VariableDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ],
+            "declarations": [
+                {
+                    "type": "VariableDeclarator",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 4
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 7
+                        }
+                    },
+                    "range": [
+                        4,
+                        7
+                    ],
+                    "id": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 4
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 7
+                            }
+                        },
+                        "range": [
+                            4,
+                            7
+                        ],
+                        "name": "foo"
+                    },
+                    "init": null
+                }
+            ],
+            "kind": "let"
+        },
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 25
+                }
+            },
+            "range": [
+                9,
+                34
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 2,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 2,
+                            "column": 22
+                        }
+                    },
+                    "range": [
+                        18,
+                        31
+                    ],
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 12
+                            }
+                        },
+                        "range": [
+                            18,
+                            21
+                        ],
+                        "name": "foo"
+                    },
+                    "exported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 2,
+                                "column": 16
+                            },
+                            "end": {
+                                "line": 2,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            25,
+                            31
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    }
+                }
+            ],
+            "source": null
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "let",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            },
+            "range": [
+                0,
+                3
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "range": [
+                4,
+                7
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 6
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 7
+                },
+                "end": {
+                    "line": 2,
+                    "column": 8
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 9
+                },
+                "end": {
+                    "line": 2,
+                    "column": 12
+                }
+            },
+            "range": [
+                18,
+                21
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 13
+                },
+                "end": {
+                    "line": 2,
+                    "column": 15
+                }
+            },
+            "range": [
+                22,
+                24
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 16
+                },
+                "end": {
+                    "line": 2,
+                    "column": 22
+                }
+            },
+            "range": [
+                25,
+                31
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 23
+                },
+                "end": {
+                    "line": 2,
+                    "column": 24
+                }
+            },
+            "range": [
+                32,
+                33
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 24
+                },
+                "end": {
+                    "line": 2,
+                    "column": 25
+                }
+            },
+            "range": [
+                33,
+                34
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-exported.src.js
@@ -1,0 +1,2 @@
+let foo;
+export { foo as " 👶 " };

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-exported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-exported.result.js
@@ -1,0 +1,277 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 36
+        }
+    },
+    "range": [
+        0,
+        36
+    ],
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                0,
+                36
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 22
+                        }
+                    },
+                    "range": [
+                        9,
+                        22
+                    ],
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 12
+                            }
+                        },
+                        "range": [
+                            9,
+                            12
+                        ],
+                        "name": "foo"
+                    },
+                    "exported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 16
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            16,
+                            22
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 30
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 35
+                    }
+                },
+                "range": [
+                    30,
+                    35
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                13,
+                15
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                16,
+                22
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                23,
+                24
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                25,
+                29
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            },
+            "range": [
+                30,
+                35
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                35,
+                36
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-exported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-exported.src.js
@@ -1,0 +1,1 @@
+export { foo as " 👶 " } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local-and-exported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local-and-exported.result.js
@@ -1,0 +1,278 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 39
+        }
+    },
+    "range": [
+        0,
+        39
+    ],
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "range": [
+                0,
+                39
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 25
+                        }
+                    },
+                    "range": [
+                        9,
+                        25
+                    ],
+                    "local": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            9,
+                            15
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    },
+                    "exported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 19
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 25
+                            }
+                        },
+                        "range": [
+                            19,
+                            25
+                        ],
+                        "value": " 👍 ",
+                        "raw": "\" 👍 \""
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 33
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 38
+                    }
+                },
+                "range": [
+                    33,
+                    38
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "range": [
+                16,
+                18
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👍 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                19,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            },
+            "range": [
+                28,
+                32
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 38
+                }
+            },
+            "range": [
+                33,
+                38
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 38
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "range": [
+                38,
+                39
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local-and-exported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local-and-exported.src.js
@@ -1,0 +1,1 @@
+export { " 👶 " as " 👍 " } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local.result.js
@@ -1,0 +1,277 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 36
+        }
+    },
+    "range": [
+        0,
+        36
+    ],
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                0,
+                36
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 22
+                        }
+                    },
+                    "range": [
+                        9,
+                        22
+                    ],
+                    "local": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            9,
+                            15
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    },
+                    "exported": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 19
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            19,
+                            22
+                        ],
+                        "name": "foo"
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 30
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 35
+                    }
+                },
+                "range": [
+                    30,
+                    35
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "range": [
+                16,
+                18
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                19,
+                22
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                23,
+                24
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                25,
+                29
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            },
+            "range": [
+                30,
+                35
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                35,
+                36
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-local.src.js
@@ -1,0 +1,1 @@
+export { " 👶 " as foo } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-shorthand.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-shorthand.result.js
@@ -1,0 +1,242 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 29
+        }
+    },
+    "range": [
+        0,
+        29
+    ],
+    "body": [
+        {
+            "type": "ExportNamedDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                0,
+                29
+            ],
+            "declaration": null,
+            "specifiers": [
+                {
+                    "type": "ExportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 15
+                        }
+                    },
+                    "range": [
+                        9,
+                        15
+                    ],
+                    "local": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            9,
+                            15
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    },
+                    "exported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            9,
+                            15
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 23
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 28
+                    }
+                },
+                "range": [
+                    23,
+                    28
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "export",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                18,
+                22
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                23,
+                28
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-shorthand.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/export-from-shorthand.src.js
@@ -1,0 +1,1 @@
+export { " 👶 " } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported-with-escapes.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported-with-escapes.result.js
@@ -1,0 +1,276 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 46
+        }
+    },
+    "range": [
+        0,
+        46
+    ],
+    "body": [
+        {
+            "type": "ImportDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 46
+                }
+            },
+            "range": [
+                0,
+                46
+            ],
+            "specifiers": [
+                {
+                    "type": "ImportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 32
+                        }
+                    },
+                    "range": [
+                        9,
+                        32
+                    ],
+                    "imported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 25
+                            }
+                        },
+                        "range": [
+                            9,
+                            25
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" \\uD83D\\uDC76 \""
+                    },
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 29
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 32
+                            }
+                        },
+                        "range": [
+                            29,
+                            32
+                        ],
+                        "name": "foo"
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 40
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 45
+                    }
+                },
+                "range": [
+                    40,
+                    45
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "import",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" \\uD83D\\uDC76 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                9,
+                25
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                26,
+                28
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 1,
+                    "column": 32
+                }
+            },
+            "range": [
+                29,
+                32
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 33
+                },
+                "end": {
+                    "line": 1,
+                    "column": 34
+                }
+            },
+            "range": [
+                33,
+                34
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 39
+                }
+            },
+            "range": [
+                35,
+                39
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 40
+                },
+                "end": {
+                    "line": 1,
+                    "column": 45
+                }
+            },
+            "range": [
+                40,
+                45
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 45
+                },
+                "end": {
+                    "line": 1,
+                    "column": 46
+                }
+            },
+            "range": [
+                45,
+                46
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported-with-escapes.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported-with-escapes.src.js
@@ -1,0 +1,1 @@
+import { " \uD83D\uDC76 " as foo } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported.result.js
@@ -1,0 +1,276 @@
+export default {
+    "type": "Program",
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 36
+        }
+    },
+    "range": [
+        0,
+        36
+    ],
+    "body": [
+        {
+            "type": "ImportDeclaration",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                0,
+                36
+            ],
+            "specifiers": [
+                {
+                    "type": "ImportSpecifier",
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 22
+                        }
+                    },
+                    "range": [
+                        9,
+                        22
+                    ],
+                    "imported": {
+                        "type": "Literal",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 15
+                            }
+                        },
+                        "range": [
+                            9,
+                            15
+                        ],
+                        "value": " 👶 ",
+                        "raw": "\" 👶 \""
+                    },
+                    "local": {
+                        "type": "Identifier",
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 19
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 22
+                            }
+                        },
+                        "range": [
+                            19,
+                            22
+                        ],
+                        "name": "foo"
+                    }
+                }
+            ],
+            "source": {
+                "type": "Literal",
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 30
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 35
+                    }
+                },
+                "range": [
+                    30,
+                    35
+                ],
+                "value": "mod",
+                "raw": "\"mod\""
+            }
+        }
+    ],
+    "sourceType": "module",
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "import",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                0,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\" 👶 \"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                9,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "as",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 18
+                }
+            },
+            "range": [
+                16,
+                18
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                19,
+                22
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 24
+                }
+            },
+            "range": [
+                23,
+                24
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "from",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 25
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                25,
+                29
+            ]
+        },
+        {
+            "type": "String",
+            "value": "\"mod\"",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 35
+                }
+            },
+            "range": [
+                30,
+                35
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ";",
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 35
+                },
+                "end": {
+                    "line": 1,
+                    "column": 36
+                }
+            },
+            "range": [
+                35,
+                36
+            ]
+        }
+    ]
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/import-imported.src.js
@@ -1,0 +1,1 @@
+import { " 👶 " as foo } from "mod";

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-export-exported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-export-exported.result.js
@@ -1,0 +1,6 @@
+export default {
+    "message": "An export name cannot include a lone surrogate.",
+    "column": 17,
+    "index": 25,
+    "lineNumber": 2
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-export-exported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-export-exported.src.js
@@ -1,0 +1,2 @@
+let foo;
+export { foo as " \uD83D " };

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-import-imported.result.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-import-imported.result.js
@@ -1,0 +1,6 @@
+export default {
+    "message": "An export name cannot include a lone surrogate.",
+    "column": 10,
+    "index": 9,
+    "lineNumber": 1
+};

--- a/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-import-imported.src.js
+++ b/tests/fixtures/ecma-version/13/modules/arbitrary-module-namespace-names/invalid-lone-surrogate-import-imported.src.js
@@ -1,0 +1,1 @@
+import { " \uD83D " as foo } from "mod";


### PR DESCRIPTION
Upgrades Acorn to support [Arbitrary module namespace names](https://github.com/tc39/ecma262/pull/2154).