### PR TITLE
chore: upgrade eslint-visitor-keys@3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "acorn": "^8.7.0",
     "acorn-jsx": "^5.3.1",
-    "eslint-visitor-keys": "^3.1.0"
+    "eslint-visitor-keys": "^3.2.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Updates `eslint-visitor-key` dependency to include https://github.com/eslint/eslint-visitor-keys/commit/5c532184e05440d3c883b3d7864f84eb1b11dc90