### PR TITLE
chore: Upgrade to eslint-visitor-keys@3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "acorn": "^8.7.0",
     "acorn-jsx": "^5.3.1",
-    "eslint-visitor-keys": "^3.2.0"
+    "eslint-visitor-keys": "^3.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Updates eslint-visitor-keys dependency to ^3.3.0