### PR TITLE
ci: use LTS node version in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: 'lts/*'
       - name: Install dependencies
         run: npm install
       - name: Build commonjs


### PR DESCRIPTION
Use the [Node.js LTS version syntax](https://github.com/actions/setup-node#supported-version-syntax) so we don't have to manually update the node version in the future.