### PR TITLE
feat: Add parser name

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -149,16 +149,16 @@ export const VisitorKeys = (function() {
 // Derive node types from VisitorKeys
 /* istanbul ignore next */
 export const Syntax = (function() {
-    let name,
+    let key,
         types = {};
 
     if (typeof Object.create === "function") {
         types = Object.create(null);
     }
 
-    for (name in VisitorKeys) {
-        if (Object.hasOwnProperty.call(VisitorKeys, name)) {
-            types[name] = name;
+    for (key in VisitorKeys) {
+        if (Object.hasOwnProperty.call(VisitorKeys, key)) {
+            types[key] = key;
         }
     }
 

--- a/espree.js
+++ b/espree.js
@@ -139,6 +139,7 @@ export function parse(code, options) {
 //------------------------------------------------------------------------------
 
 export const version = espreeVersion;
+export const name = "espree";
 
 /* istanbul ignore next */
 export const VisitorKeys = (function() {


### PR DESCRIPTION
This change adds a `name` export so that Espree can be properly serialized with the new serialization strategy in ESLint.

Refs https://github.com/eslint/eslint/pull/16944