### PR TITLE
chore: set up release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,41 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: 'espree'
+          pull-request-title-pattern: 'chore: release${component} ${version}'
+      - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}
+      - run: 'npx @humanwhocodes/tweet "espree ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      - run: 'npx @humanwhocodes/toot "espree ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,18 @@ jobs:
           release-type: node
           package-name: 'espree'
           pull-request-title-pattern: 'chore: release${component} ${version}'
+          changelog-types: >
+            [
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Bug Fixes", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false },
+              { "type": "build", "section": "Build Related", "hidden": false },
+              { "type": "chore", "section": "Chores", "hidden": false },
+              { "type": "perf", "section": "Chores", "hidden": false },
+              { "type": "ci", "section": "Chores", "hidden": false },
+              { "type": "refactor", "section": "Chores", "hidden": false },
+              { "type": "test", "section": "Chores", "hidden": false }
+            ]
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Referencing the checklist from #563, I was still able to complete the first two independently, but one of the TSC members will need to complete the third item:

- [x] Update [npm package settings](https://www.npmjs.com/package/@eslint/espree/access) to allow publishing with 2FA **or** automation or granular access tokens.

In setting this up previously on other repositories, some packages already had this setting enabled, so don't be surprised if that's the case.

Fixes #563

To ease review, this differs from https://github.com/eslint/create-config/blob/9fc2de4eb76dd04218b5a4c72a6006563c74f589/.github/workflows/release-please.yml only by the package name:

```diff
diff --git ../create-config/.github/workflows/release-please.yml ./.github/workflows/release-please.yml
index 49defac..371943e 100644
--- ../create-config/.github/workflows/release-please.yml
+++ ./.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
         id: release
         with:
           release-type: node
-          package-name: '@eslint/create-config'
+          package-name: 'espree'
           pull-request-title-pattern: 'chore: release${component} ${version}'
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
@@ -27,14 +27,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
-      - run: 'npx @humanwhocodes/tweet "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+      - run: 'npx @humanwhocodes/tweet "espree ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
         if: ${{ steps.release.outputs.release_created }}
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-      - run: 'npx @humanwhocodes/toot "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+      - run: 'npx @humanwhocodes/toot "espree ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
         if: ${{ steps.release.outputs.release_created }}
         env:
           MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}

```