### PR TITLE
chore: Add PRs to triage project

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
       - opened
+  pull_request:
+    types:
+      - opened
 
 jobs:
   add-to-project:


### PR DESCRIPTION
Adds PRs to the triage project so we can manage issues and PRs in one place.