### PR TITLE
ci: run tests in Node.js 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: [21.x, 20.x, 19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
           node: "16.x"


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to run tests also in Node.js 21.