### PR TITLE
fix: Espree usage as acorn plugin

### DIFF
--- a/espree.js
+++ b/espree.js
@@ -175,3 +175,5 @@ export const Syntax = (function() {
 export const latestEcmaVersion = getLatestEcmaVersion();
 
 export const supportedEcmaVersions = getSupportedEcmaVersions();
+
+export { espree as espreeAcornPlugin };

--- a/lib/options.js
+++ b/lib/options.js
@@ -92,8 +92,8 @@ function normalizeSourceType(sourceType = "script") {
 export function normalizeOptions(options) {
     const ecmaVersion = normalizeEcmaVersion(options.ecmaVersion);
     const sourceType = normalizeSourceType(options.sourceType);
-    const ranges = options.range === true;
-    const locations = options.loc === true;
+    const ranges = options.range === true || options.ranges === true;
+    const locations = options.loc === true || options.locations === true;
 
     if (ecmaVersion !== 3 && options.allowReserved) {
 


### PR DESCRIPTION
Changes to support #593:

1. Add export of plugin function to main module which allows use as:
  ```js
  import { espreeAcornPlugin as espree } from 'espree';
  
  const AzothEspreeParser = AcornParser.extend(azoth(), espree());
  ```

2. Respect acorn settings alias for `locations` and `ranges`. Still requires setting new, additive options `tokens` and `comment` but at least minimizes head-scratching over why standard option keys aren't working.