### PR TITLE
chore: upgrade eslint-visitor-keys@4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "acorn": "^8.11.3",
     "acorn-jsx": "^5.3.2",
-    "eslint-visitor-keys": "^3.4.1"
+    "eslint-visitor-keys": "^4.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.1.0",


### PR DESCRIPTION
Updates `eslint-visitor-keys` dependency to just-released v4.0.0.