### PR TITLE
chore: update dependency shelljs to v0.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "^9.2.2",
     "npm-run-all": "^4.1.5",
     "rollup": "^2.41.2",
-    "shelljs": "^0.3.0",
+    "shelljs": "^0.8.5",
     "yorkie": "^2.0.0"
   },
   "keywords": [

--- a/tests/lib/libraries.js
+++ b/tests/lib/libraries.js
@@ -13,6 +13,7 @@ import tester from "./tester.js";
 import * as espree from "../../espree.js";
 import assert from "assert";
 import { fileURLToPath } from "url";
+import { readFile } from "fs/promises";
 
 // eslint-disable-next-line no-underscore-dangle -- Conventional
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -34,9 +35,9 @@ describe("Libraries", () => {
 
             // var filename = "angular-1.2.5.js";
 
-            it("should produce correct AST when parsed", () => {
-                const output = shelljs.cat(`${filename}.result.json`);
-                const input = shelljs.cat(filename);
+            it("should produce correct AST when parsed", async () => {
+                const output = await readFile(`${filename}.result.json`, "utf-8");
+                const input = await readFile(filename, "utf-8");
                 const result = JSON.stringify(tester.getRaw(espree.parse(input, {
                     ecmaVersion: 5,
                     loc: true,


### PR DESCRIPTION
Versions of shelljs prior to v.0.8.5 are affected by a high rated security vulnerability. It's unlikely that anyone working with this repo has one of those older versions installed, but they are not automatically updated as long as they match the version range in package.json. This PR updates package.json to ensure that only shelljs ^0.8.5 is used.

It also updates a unit test to use native Node.js API to read files.

NVD advisory: https://nvd.nist.gov/vuln/detail/CVE-2022-0144