### PR TITLE
ci: auto update sponsors in README

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,35 @@
+name: Data Fetch
+
+on:
+    schedule:
+        - cron: "0 8 * * *" # Every day at 1am PDT
+    workflow_dispatch:
+    pull_request:
+
+jobs:
+    update-readme:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out repo
+              uses: actions/checkout@v4
+              with:
+                token: ${{ secrets.WORKFLOW_PUSH_BOT_TOKEN }}
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+
+            - name: Install npm packages
+              run: npm install --force
+
+            - name: Update README with latest team and sponsor data
+              run: npm run build:readme
+
+            - name: Setup Git
+              run: |
+                git config user.name "GitHub Actions Bot"
+                git config user.email "<eslint@googlegroups.com>"
+
+            # - name: Save updated files
+            #   run: |
+            #     chmod +x ./tools/commit-readme.sh
+            #     ./tools/commit-readme.sh

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -4,7 +4,6 @@ on:
     schedule:
         - cron: "0 8 * * *" # Every day at 1am PDT
     workflow_dispatch:
-    pull_request:
 
 jobs:
     update-readme:
@@ -29,7 +28,7 @@ jobs:
                 git config user.name "GitHub Actions Bot"
                 git config user.email "<eslint@googlegroups.com>"
 
-            # - name: Save updated files
-            #   run: |
-            #     chmod +x ./tools/commit-readme.sh
-            #     ./tools/commit-readme.sh
+            - name: Save updated files
+              run: |
+                chmod +x ./tools/commit-readme.sh
+                ./tools/commit-readme.sh

--- a/tools/commit-readme.sh
+++ b/tools/commit-readme.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+#------------------------------------------------------------------------------
+# Commits the data files if any have changed
+#------------------------------------------------------------------------------
+
+if [ -z "$(git status --porcelain)" ]; then 
+	echo "Data did not change."
+else
+	echo "Data changed!"
+
+	# commit the result
+	git add README.md packages/**/README.md
+	git commit -m "docs: Update README sponsors"
+
+	# push back to source control
+	git push origin HEAD  
+fi


### PR DESCRIPTION
Cron job to update sponsors in README.

We need to enable the `secrets.WORKFLOW_PUSH_BOT_TOKEN` secret for this repo. Can someone with access do it?