### PR TITLE
chore: remove unused dev dependency `json-diff`

### DIFF
--- a/packages/eslint-visitor-keys/package.json
+++ b/packages/eslint-visitor-keys/package.json
@@ -30,7 +30,6 @@
     "@types/estree-jsx": "^0.0.2",
     "@typescript-eslint/parser": "^8.7.0",
     "esquery": "^1.4.0",
-    "json-diff": "^0.7.3",
     "opener": "^1.5.2",
     "rollup": "^4.22.4",
     "rollup-plugin-dts": "^6.1.1",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Removes eslint-visitor-keys's dev dependency `json-diff` because it's unused.

#### What changes did you make? (Give an overview)

Removed the dependency from package.json

#### Related Issues

This dependency is unused since https://github.com/eslint/js/commit/e8cd107d732fb7ef62cd4f6cd179bd48f5c13b27.

#### Is there anything you'd like reviewers to focus on?
