### PR TITLE
fix!: remove `nodejsScope` option

### DIFF
--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -31,10 +31,9 @@ In order to analyze scope, you'll need to have an [ESTree](https://github.com/es
 1. `ast` - the ESTree-compliant AST structure to analyze.
 2. `options` (optional) - Options to adjust how the scope is analyzed, including:
   * `ignoreEval` (default: `false`) - Set to `true` to ignore all `eval()` calls (which would normally create scopes).
-  * `nodejsScope` (default: `false`) - Set to `true` to create a top-level function scope needed for CommonJS evaluation.
   * `impliedStrict` (default: `false`) - Set to `true` to evaluate the code in strict mode even outside of modules and without `"use strict"`.
   * `ecmaVersion` (default: `5`) - The version of ECMAScript to use to evaluate the code.
-  * `sourceType` (default: `"script"`) - The type of JavaScript file to evaluate. Change to `"module"` for ECMAScript module code.
+  * `sourceType` (default: `"script"`) - The type of JavaScript file to evaluate. Change to `"module"` for ECMAScript module code, or `"commonjs"` for CommonJS module code.
   * `childVisitorKeys` (default: `null`) - An object with visitor key information (like [`eslint-visitor-keys`](https://github.com/eslint/js/tree/main/packages/eslint-visitor-keys)). Without this, `eslint-scope` finds child nodes to visit algorithmically. Providing this option is a performance enhancement.
   * `fallback` (default: `"iteration"`) - The strategy to use when `childVisitorKeys` is not specified. May be a function.
   * `jsx` (default: `false`) - Enables the tracking of JSX components as variable references.

--- a/packages/eslint-scope/lib/index.js
+++ b/packages/eslint-scope/lib/index.js
@@ -62,7 +62,6 @@ import eslintScopeVersion from "./version.js";
 function defaultOptions() {
     return {
         optimistic: false,
-        nodejsScope: false,
         impliedStrict: false,
         sourceType: "script", // one of ['script', 'module', 'commonjs']
         ecmaVersion: 5,
@@ -114,9 +113,6 @@ function updateDeeply(target, override) {
  * @param {Object} providedOptions Options that tailor the scope analysis
  * @param {boolean} [providedOptions.optimistic=false] the optimistic flag
  * @param {boolean} [providedOptions.ignoreEval=false] whether to check 'eval()' calls
- * @param {boolean} [providedOptions.nodejsScope=false] whether the whole
- * script is executed under node.js environment. When enabled, escope adds
- * a function scope immediately following the global scope.
  * @param {boolean} [providedOptions.impliedStrict=false] implied strict mode
  * (if ecmaVersion >= 5).
  * @param {string} [providedOptions.sourceType='script'] the source type of the script. one of 'script', 'module', and 'commonjs'
@@ -125,9 +121,15 @@ function updateDeeply(target, override) {
  * @param {Object} [providedOptions.childVisitorKeys=null] Additional known visitor keys. See [esrecurse](https://github.com/estools/esrecurse)'s the `childVisitorKeys` option.
  * @param {string} [providedOptions.fallback='iteration'] A kind of the fallback in order to encounter with unknown node. See [esrecurse](https://github.com/estools/esrecurse)'s the `fallback` option.
  * @returns {ScopeManager} ScopeManager
+ * @throws {Error} When `nodejsScope` option is passed.
  */
 function analyze(tree, providedOptions) {
     const options = updateDeeply(defaultOptions(), providedOptions);
+
+    if (options.nodejsScope) {
+        throw new Error("`nodejsScope` option has been removed. To create a top-level function scope for CommonJS evaluation, set `sourceType` to 'commonjs'.");
+    }
+
     const scopeManager = new ScopeManager(options);
     const referencer = new Referencer(options, scopeManager);
 

--- a/packages/eslint-scope/lib/scope-manager.js
+++ b/packages/eslint-scope/lib/scope-manager.js
@@ -64,7 +64,7 @@ class ScopeManager {
     }
 
     isGlobalReturn() {
-        return this.__options.nodejsScope || this.__options.sourceType === "commonjs";
+        return this.__options.sourceType === "commonjs";
     }
 
     isModule() {

--- a/packages/eslint-scope/lib/scope.js
+++ b/packages/eslint-scope/lib/scope.js
@@ -722,7 +722,7 @@ class FunctionScope extends Scope {
     //     }
     __isValidResolution(ref, variable) {
 
-        // If `options.nodejsScope` is true, `this.block` becomes a Program node.
+        // If `options.sourceType` is "commonjs", `this.block` becomes a Program node.
         if (this.block.type === "Program") {
             return true;
         }

--- a/packages/eslint-scope/tests/commonjs-scope.test.js
+++ b/packages/eslint-scope/tests/commonjs-scope.test.js
@@ -25,34 +25,7 @@ import { expect } from "chai";
 import espree from "./util/espree.js";
 import { analyze } from "../lib/index.js";
 
-describe("nodejsScope option", () => {
-
-    it("creates a function scope following the global scope immediately when nodejscope: true", () => {
-        const ast = espree(`
-            "use strict";
-            var hello = 20;
-        `);
-
-        const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true });
-
-        expect(scopeManager.scopes).to.have.length(2);
-        expect(scopeManager.isGlobalReturn()).to.be.true;
-
-        let scope = scopeManager.scopes[0];
-
-        expect(scope.type).to.be.equal("global");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.false;
-        expect(scope.variables).to.have.length(0);
-
-        scope = scopeManager.scopes[1];
-        expect(scope.type).to.be.equal("function");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.true;
-        expect(scope.variables).to.have.length(2);
-        expect(scope.variables[0].name).to.be.equal("arguments");
-        expect(scope.variables[1].name).to.be.equal("hello");
-    });
+describe("commonjs scope", () => {
 
     it("creates a function scope following the global scope immediately when sourceType:commonjs", () => {
         const ast = espree(`
@@ -81,35 +54,17 @@ describe("nodejsScope option", () => {
         expect(scope.variables[1].name).to.be.equal("hello");
     });
 
-    it("creates a function scope following the global scope immediately and creates module scope", () => {
-        const ast = espree("import {x as v} from 'mod';");
+    it("analyze() throws an error when `nodejsScope:true` option is passed", () => {
+        const ast = espree(`
+            "use strict";
+            var hello = 20;
+        `);
 
-        const scopeManager = analyze(ast, { ecmaVersion: 6, nodejsScope: true, sourceType: "module" });
-
-        expect(scopeManager.scopes).to.have.length(3);
-        expect(scopeManager.isGlobalReturn()).to.be.true;
-
-        let scope = scopeManager.scopes[0];
-
-        expect(scope.type).to.be.equal("global");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.false;
-        expect(scope.variables).to.have.length(0);
-
-        scope = scopeManager.scopes[1];
-        expect(scope.type).to.be.equal("function");
-        expect(scope.block.type).to.be.equal("Program");
-        expect(scope.isStrict).to.be.false;
-        expect(scope.variables).to.have.length(1);
-        expect(scope.variables[0].name).to.be.equal("arguments");
-
-        scope = scopeManager.scopes[2];
-        expect(scope.type).to.be.equal("module");
-        expect(scope.variables).to.have.length(1);
-        expect(scope.variables[0].name).to.be.equal("v");
-        expect(scope.variables[0].defs[0].type).to.be.equal("ImportBinding");
-        expect(scope.references).to.have.length(0);
+        expect(() => analyze(ast, { ecmaVersion: 6, nodejsScope: true })).to.throw(
+            "`nodejsScope` option has been removed. To create a top-level function scope for CommonJS evaluation, set `sourceType` to 'commonjs'."
+        );
     });
+
 });
 
 // vim: set sw=4 ts=4 et tw=80 :

--- a/packages/eslint-scope/tests/implied-strict.test.js
+++ b/packages/eslint-scope/tests/implied-strict.test.js
@@ -80,12 +80,12 @@ describe("impliedStrict option", () => {
         expect(scope.isStrict).to.be.false;
     });
 
-    it("omits a nodejs global scope when ensuring all user scopes are strict", () => {
+    it("omits a commonjs global scope when ensuring all user scopes are strict", () => {
         const ast = espree(`
             function foo() {}
         `);
 
-        const scopeManager = analyze(ast, { ecmaVersion: 5, nodejsScope: true, impliedStrict: true });
+        const scopeManager = analyze(ast, { ecmaVersion: 5, sourceType: "commonjs", impliedStrict: true });
 
         expect(scopeManager.scopes).to.have.length(3);
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Removes `nodejsScope` option from `eslint-scope`.

#### What changes did you make? (Give an overview)

Removed the option and updated `analyze()` to throw an error if it's passed.

#### Related Issues

Fixes #697

#### Is there anything you'd like reviewers to focus on?
