### PR TITLE
chore: enable `exactOptionalPropertyTypes`

### DIFF
--- a/packages/eslint-visitor-keys/tsconfig.json
+++ b/packages/eslint-visitor-keys/tsconfig.json
@@ -11,6 +11,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "strict": true,
+    "exactOptionalPropertyTypes": true,
     "target": "es6",
     "outDir": "dist"
   },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR includes a small change.

In this PR, I've enabled `"exactOptionalPropertyTypes": true` in `eslint-visitor-keys`.

The `strict` mode doesn't include `exactOptionalPropertyTypes` (ref: https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes), and there have been type issues when not enabling it in other packages — for example, https://github.com/eslint/markdown/issues/402. 

Also, the `rewrite`, `css`, `json`, and `markdown` repositories have enabled `exactOptionalPropertyTypes` for their type tests.

- https://github.com/eslint/css/blob/main/tests/types/tsconfig.json#L7
- https://github.com/eslint/json/blob/main/tests/types/tsconfig.json#L7
- https://github.com/eslint/markdown/blob/main/tests/types/tsconfig.json#L8
- https://github.com/eslint/rewrite/blob/main/packages/core/tests/types/tsconfig.json#L4

So, I think it would be helpful if we can enable it.

#### What changes did you make? (Give an overview)

In this PR, I've enabled `"exactOptionalPropertyTypes": true` in `eslint-visitor-keys`.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A