### PR TITLE
test: use type only import in type test to fix CI failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-expect-type": "^0.6.2",
     "globals": "^17.0.0",
-    "knip": "^6.0.0",
+    "knip": "^6.11.0",
     "lint-staged": "^16.0.0",
     "mocha": "^11.1.0",
     "prettier": "3.8.3",

--- a/packages/eslint-scope/tests/types/types.test.ts
+++ b/packages/eslint-scope/tests/types/types.test.ts
@@ -25,10 +25,10 @@
  * SOFTWARE
  */
 
-import * as eslint from "eslint";
 import * as eslintScope from "eslint-scope";
 import * as espree from "espree";
-import * as estree from "estree";
+import type * as eslint from "eslint";
+import type * as estree from "estree";
 
 const code = `
 function example() {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

## AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## What is the purpose of this pull request?

This PR fixes an issue where the main branch's CI is failing due to the newly released `knip`.

https://github.com/eslint/js/actions/runs/25274353285/job/74101743732

<img width="1493" height="220" alt="image" src="https://github.com/user-attachments/assets/06e090a2-e8eb-40a5-92cf-4a53677ffcb8" />

## What changes did you make? (Give an overview)

It seems that newer versions of `knip` have become stricter when checking imports, so type-only imports now need to be explicitly marked with `type`.

I'm not entirely sure which part exactly made this happen, but `knip` v6.10 introduced some related changes.

https://github.com/webpro-nl/knip/releases/tag/knip%406.10.0

<img width="463" height="57" alt="image" src="https://github.com/user-attachments/assets/16287fb9-1cb4-4892-a43d-c601b4534b67" />

## Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

## Is there anything you'd like reviewers to focus on?

N/A