### PR TITLE
chore: update stale links and use latest `eslint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.19.0",
     "@typescript-eslint/parser": "^8.56.1",
     "c8": "^11.0.0",
-    "eslint": "^10.0.3",
+    "eslint": "^10.3.0",
     "eslint-config-eslint": "^14.0.0",
     "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-expect-type": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^20.19.0",
     "@typescript-eslint/parser": "^8.56.1",
     "c8": "^11.0.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.0",
     "eslint-config-eslint": "^14.0.0",
     "eslint-plugin-chai-friendly": "^1.0.0",
     "eslint-plugin-expect-type": "^0.6.2",

--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -4,7 +4,7 @@
 
 # ESLint Scope
 
-ESLint Scope is the [ECMAScript](https://ecma-international.org/publications-and-standards/standards/ecma-262) scope analyzer used in ESLint. It is a fork of [escope](https://github.com/estools/escope).
+ESLint Scope is the [ECMAScript](https://ecma-international.org/publications-and-standards/standards/ecma-262/) scope analyzer used in ESLint. It is a fork of [escope](https://github.com/estools/escope).
 
 ## Install
 

--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -173,7 +173,7 @@ Each variable object has the following properties:
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 ## Security Policy
 

--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -1,10 +1,10 @@
 [![npm version](https://img.shields.io/npm/v/eslint-scope.svg)](https://www.npmjs.com/package/eslint-scope)
-[![Downloads](https://img.shields.io/npm/dm/eslint-scope.svg)](https://www.npmjs.com/package/eslint-scope)
-[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/eslint/js/actions)
+[![npm downloads per month](https://img.shields.io/npm/dm/eslint-scope.svg)](https://www.npmjs.com/package/eslint-scope)
+[![CI Status](https://github.com/eslint/js/actions/workflows/ci.yml/badge.svg)](https://github.com/eslint/js/actions/workflows/ci.yml)
 
 # ESLint Scope
 
-ESLint Scope is the [ECMAScript](http://www.ecma-international.org/publications/standards/Ecma-262.htm) scope analyzer used in ESLint. It is a fork of [escope](http://github.com/estools/escope).
+ESLint Scope is the [ECMAScript](https://ecma-international.org/publications-and-standards/standards/ecma-262) scope analyzer used in ESLint. It is a fork of [escope](https://github.com/estools/escope).
 
 ## Install
 
@@ -173,7 +173,7 @@ Each variable object has the following properties:
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 ## Security Policy
 

--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -173,7 +173,7 @@ Each variable object has the following properties:
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 ## Security Policy
 

--- a/packages/eslint-scope/package.json
+++ b/packages/eslint-scope/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^8.7.0",
     "chai": "^6.0.0",
-    "eslint": ">=10.0.0-rc.0 <10.0.0 || ^10.0.0",
+    "eslint": "^10.3.0",
     "eslint-visitor-keys": "^5.0.1",
     "espree": "^11.2.0",
     "npm-license": "^0.3.3",

--- a/packages/eslint-scope/package.json
+++ b/packages/eslint-scope/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@typescript-eslint/parser": "^8.7.0",
     "chai": "^6.0.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.4.0",
     "eslint-visitor-keys": "^5.0.1",
     "espree": "^11.2.0",
     "npm-license": "^0.3.3",

--- a/packages/eslint-visitor-keys/README.md
+++ b/packages/eslint-visitor-keys/README.md
@@ -1,7 +1,7 @@
 # eslint-visitor-keys
 
 [![npm version](https://img.shields.io/npm/v/eslint-visitor-keys.svg)](https://www.npmjs.com/package/eslint-visitor-keys)
-[![npm downloads per month](https://img.shields.io/npm/dm/eslint-visitor-keys.svg)](https://www.npmtrends.com/eslint-visitor-keys)
+[![npm downloads per month](https://img.shields.io/npm/dm/eslint-visitor-keys.svg)](https://www.npmjs.com/package/eslint-visitor-keys)
 [![CI Status](https://github.com/eslint/js/actions/workflows/ci.yml/badge.svg)](https://github.com/eslint/js/actions/workflows/ci.yml)
 
 Constants and utilities about visitor keys to traverse AST.

--- a/packages/eslint-visitor-keys/README.md
+++ b/packages/eslint-visitor-keys/README.md
@@ -1,8 +1,8 @@
 # eslint-visitor-keys
 
 [![npm version](https://img.shields.io/npm/v/eslint-visitor-keys.svg)](https://www.npmjs.com/package/eslint-visitor-keys)
-[![Downloads/month](https://img.shields.io/npm/dm/eslint-visitor-keys.svg)](http://www.npmtrends.com/eslint-visitor-keys)
-[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/eslint/js/actions)
+[![npm downloads per month](https://img.shields.io/npm/dm/eslint-visitor-keys.svg)](https://www.npmtrends.com/eslint-visitor-keys)
+[![CI Status](https://github.com/eslint/js/actions/workflows/ci.yml/badge.svg)](https://github.com/eslint/js/actions/workflows/ci.yml)
 
 Constants and utilities about visitor keys to traverse AST.
 
@@ -92,13 +92,13 @@ See [GitHub releases](https://github.com/eslint/js/releases).
 
 ## 🍻 Contributing
 
-Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/developer-guide/contributing/).
+Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/latest/contribute).
 
 ### Development commands
 
 - `npm test` runs tests and measures code coverage.
 - `npm run lint` checks source codes with ESLint.
-- `npm run test:open-coverage` opens the code coverage report of the previous test with your default browser.
+- `npm run test:coverage` runs tests and generates code coverage report.
 
 [npm]: https://www.npmjs.com/
 [Node.js]: https://nodejs.org/

--- a/packages/eslint-visitor-keys/README.md
+++ b/packages/eslint-visitor-keys/README.md
@@ -92,7 +92,7 @@ See [GitHub releases](https://github.com/eslint/js/releases).
 
 ## 🍻 Contributing
 
-Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/latest/contribute).
+Welcome. See [ESLint contribution guidelines](https://eslint.org/docs/latest/contribute/).
 
 ### Development commands
 

--- a/packages/espree/CONTRIBUTING.md
+++ b/packages/espree/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing Code
 
-Please sign the [jQuery Foundation Contributor License Agreement](https://contribute.jquery.org/CLA/)
+Please sign the [OpenJS Foundation Contributor License Agreement](https://openjsf.org/cla)
 
 # Full Documentation
 
 Our full contribution guidelines can be found at:
-<http://eslint.org/docs/developer-guide/contributing/>
+<https://eslint.org/docs/latest/contribute/>
 
 # How to upgrade `acorn` to support new syntax
 

--- a/packages/espree/CONTRIBUTING.md
+++ b/packages/espree/CONTRIBUTING.md
@@ -1,13 +1,11 @@
 # Contributing Code
 
-Please sign the [OpenJS Foundation Contributor License Agreement](https://openjsf.org/cla)
-
-# Full Documentation
+## Full Documentation
 
 Our full contribution guidelines can be found at:
 <https://eslint.org/docs/latest/contribute>
 
-# How to upgrade `acorn` to support new syntax
+## How to upgrade `acorn` to support new syntax
 
 1. `npm install acorn@latest`
 1. If a new `ecmaVersion` value is added, update the `SUPPORTED_VERSIONS` constant in `lib/options.js`, the tests in `tests/lib/supported-ecmaversions.js`, and the `EcmaVersion` type.

--- a/packages/espree/CONTRIBUTING.md
+++ b/packages/espree/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please sign the [OpenJS Foundation Contributor License Agreement](https://openjs
 # Full Documentation
 
 Our full contribution guidelines can be found at:
-<https://eslint.org/docs/latest/contribute>
+<https://eslint.org/docs/latest/contribute/>
 
 # How to upgrade `acorn` to support new syntax
 

--- a/packages/espree/CONTRIBUTING.md
+++ b/packages/espree/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Please sign the [OpenJS Foundation Contributor License Agreement](https://openjs
 # Full Documentation
 
 Our full contribution guidelines can be found at:
-<https://eslint.org/docs/latest/contribute/>
+<https://eslint.org/docs/latest/contribute>
 
 # How to upgrade `acorn` to support new syntax
 

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -171,7 +171,7 @@ Espree may also deviate from Esprima in the interface it exposes.
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 Espree is licensed under a permissive BSD 2-clause license.
 

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -1,11 +1,10 @@
 [![npm version](https://img.shields.io/npm/v/espree.svg)](https://www.npmjs.com/package/espree)
-[![npm downloads](https://img.shields.io/npm/dm/espree.svg)](https://www.npmjs.com/package/espree)
-[![Build Status](https://github.com/eslint/js/workflows/CI/badge.svg)](https://github.com/js/espree/actions)
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=9348450)](https://www.bountysource.com/trackers/9348450-eslint?utm_source=9348450&utm_medium=shield&utm_campaign=TRACKER_BADGE)
+[![npm downloads per month](https://img.shields.io/npm/dm/espree.svg)](https://www.npmjs.com/package/espree)
+[![CI Status](https://github.com/eslint/js/actions/workflows/ci.yml/badge.svg)](https://github.com/eslint/js/actions/workflows/ci.yml)
 
 # Espree
 
-Espree started out as a fork of [Esprima](http://esprima.org) v1.2.2, the last stable published released of Esprima before work on ECMAScript 6 began. Espree is now built on top of [Acorn](https://github.com/ternjs/acorn), which has a modular architecture that allows extension of core functionality. The goal of Espree is to produce output that is similar to Esprima with a similar API so that it can be used in place of Esprima.
+Espree started out as a fork of [Esprima](https://esprima.org) v1.2.2, the last stable published released of Esprima before work on ECMAScript 6 began. Espree is now built on top of [Acorn](https://github.com/acornjs/acorn), which has a modular architecture that allows extension of core functionality. The goal of Espree is to produce output that is similar to Esprima with a similar API so that it can be used in place of Esprima.
 
 ## Usage
 
@@ -172,7 +171,7 @@ Espree may also deviate from Esprima in the interface it exposes.
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](http://eslint.org/docs/developer-guide/contributing), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 Espree is licensed under a permissive BSD 2-clause license.
 
@@ -212,7 +211,7 @@ In an effort to help those wanting to transition from other parsers to Espree, t
 
 ### Why another parser
 
-[ESLint](http://eslint.org) had been relying on Esprima as its parser from the beginning. While that was fine when the JavaScript language was evolving slowly, the pace of development increased dramatically and Esprima had fallen behind. ESLint, like many other tools reliant on Esprima, has been stuck in using new JavaScript language features until Esprima updates, and that caused our users frustration.
+[ESLint](https://eslint.org) had been relying on Esprima as its parser from the beginning. While that was fine when the JavaScript language was evolving slowly, the pace of development increased dramatically and Esprima had fallen behind. ESLint, like many other tools reliant on Esprima, has been stuck in using new JavaScript language features until Esprima updates, and that caused our users frustration.
 
 We decided the only way for us to move forward was to create our own parser, bringing us inline with JSHint and JSLint, and allowing us to keep implementing new features as we need them. We chose to fork Esprima instead of starting from scratch in order to move as quickly as possible with a compatible API.
 

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -171,7 +171,7 @@ Espree may also deviate from Esprima in the interface it exposes.
 
 ## Contributing
 
-Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
+Issues and pull requests will be triaged and responded to as quickly as possible. We operate under the [ESLint Contributor Guidelines](https://eslint.org/docs/latest/contribute/), so please be sure to read them before contributing. If you're not sure where to dig in, check out the [issues](https://github.com/eslint/js/issues).
 
 Espree is licensed under a permissive BSD 2-clause license.
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR updates stale links and uses the latest `eslint` packages in `package.json`.

#### What changes did you make? (Give an overview)

- Some badges were stale, so it was always failing and broken:

<img width="213" height="40" alt="image" src="https://github.com/user-attachments/assets/6c8d6066-c851-48d1-b450-41b4cc886167" />

- Some links were stale, so they were redirected to the updated links.

- Some descriptions referenced a script that isn't used anywhere (`test:open-coverage`).

- Some links didn't use the `https` protocol, so I updated them to use `https`.

- Updated `eslint` to the latest.

I've updated all of the above.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
