### PR TITLE
docs: fix API parameter descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "knip": "^6.11.0",
     "lint-staged": "^16.0.0",
     "mocha": "^11.7.6",
-    "prettier": "3.9.4",
+    "prettier": "3.9.5",
     "rollup": "^4.55.2",
     "typescript": "^6.0.3",
     "yorkie": "^2.0.0"

--- a/packages/espree/README.md
+++ b/packages/espree/README.md
@@ -36,8 +36,8 @@ const ast = espree.parse(code);
 
 `parse` parses the given code and returns a abstract syntax tree (AST). It takes two parameters.
 
-- `code` [string]() - the code which needs to be parsed.
-- `options (Optional)` [Object]() - read more about this [here](#options).
+- `code` (`string`) - the code which needs to be parsed.
+- `options` (`Object`) - optional, read more about this [here](#options).
 
 ```js
 import * as espree from "espree";
@@ -80,8 +80,8 @@ Node {
 
 `tokenize` returns the tokens of a given code. It takes two parameters.
 
-- `code` [string]() - the code which needs to be parsed.
-- `options (Optional)` [Object]() - read more about this [here](#options).
+- `code` (`string`) - the code which needs to be parsed.
+- `options` (`Object`) - optional, read more about this [here](#options).
 
 Even if `options` is empty or undefined or `options.tokens` is `false`, it assigns it to `true` in order to get the `tokens` array
 

--- a/packages/espree/docs/README.md
+++ b/packages/espree/docs/README.md
@@ -37,8 +37,8 @@ const ast = espree.parse(code);
 
 `parse` parses the given code and returns a abstract syntax tree (AST). It takes two parameters.
 
-- `code` [string]() - the code which needs to be parsed.
-- `options (Optional)` [Object]() - read more about this [here](#options).
+- `code` (`string`) - the code which needs to be parsed.
+- `options` (`Object`) - optional, read more about this [here](#options).
 
 ```js
 import * as espree from "espree";
@@ -81,8 +81,8 @@ Node {
 
 `tokenize` returns the tokens of a given code. It takes two parameters.
 
-- `code` [string]() - the code which needs to be parsed.
-- `options (Optional)` [Object]() - read more about this [here](#options).
+- `code` (`string`) - the code which needs to be parsed.
+- `options` (`Object`) - optional, read more about this [here](#options).
 
 Even if `options` is empty or undefined or `options.tokens` is `false`, it assigns it to `true` in order to get the `tokens` array
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Fixes parameter descriptions in Espree API docs. Currently, `string` and `Object` incorrectly appear as links.

Also updates dependency prettier to v3.9.5 (closes https://github.com/eslint/js/pull/763). The above links were causing CI failure in https://github.com/eslint/js/pull/763.

#### What changes did you make? (Give an overview)

Updated Espree's README and package.json.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
