### PR TITLE
docs: fix const reassignment in eslint-scope usage example

### DIFF
--- a/packages/eslint-scope/README.md
+++ b/packages/eslint-scope/README.md
@@ -56,7 +56,7 @@ const options = {
 const ast = espree.parse(code, { range: true, ...options });
 const scopeManager = eslintScope.analyze(ast, options);
 
-const currentScope = scopeManager.acquire(ast); // global scope
+let currentScope = scopeManager.acquire(ast); // global scope
 
 estraverse.traverse(ast, {
 	enter(node, parent) {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

- Documentation update

Hello! This is a small fix for an example that currently runs into an error.

<img width="622" height="97" alt="image" src="https://github.com/user-attachments/assets/231a0ff8-3a19-4e36-aab0-5d4b95de92b8" />

In the eslint-scope usage example, `currentScope` is declared with `const`, but it gets reassigned in the `estraverse.traverse` callbacks just below. Running the example as written throws `TypeError: Assignment to constant variable.`

<img width="940" height="159" alt="image" src="https://github.com/user-attachments/assets/c7c6762f-530e-4b71-bd2a-0d287983d016" />

Looking through the history, it seems this variable was originally declared with `var`, and it looks like it got turned into `const` when the example was converted during the ESM migration (eslint/eslint-scope#71). Since the variable is reassigned, `let` fits here.

#### What changes did you make? (Give an overview)

Changed the `const` declaration to `let` (one line), so the example runs without the reassignment error.

#### Related Issues

None

#### Is there anything you'd like reviewers to focus on?

Nothing in particular. It's a docs-only one-line change.