### PR TITLE
docs: fix typos in eslint-scope JSDoc comments

### DIFF
--- a/packages/eslint-scope/lib/index.js
+++ b/packages/eslint-scope/lib/index.js
@@ -72,7 +72,7 @@ function defaultOptions() {
 }
 
 /**
- * Preform deep update on option object
+ * Perform deep update on option object
  * @param {Record<string, unknown>} target Options
  * @param {Record<string, unknown>} override Updates
  * @returns {Record<string, unknown>} Updated options

--- a/packages/eslint-scope/lib/pattern-visitor.js
+++ b/packages/eslint-scope/lib/pattern-visitor.js
@@ -32,7 +32,7 @@ const { Syntax } = estraverse;
 /**
  * Get last array element
  * @param {Array} xs array
- * @returns {any} Last elment
+ * @returns {any} Last element
  */
 function getLast(xs) {
 	return xs.at(-1) || null;

--- a/packages/eslint-scope/tools/check-licenses.js
+++ b/packages/eslint-scope/tools/check-licenses.js
@@ -30,9 +30,9 @@ const OPEN_SOURCE_LICENSES = [
 //------------------------------------------------------------------------------
 
 /**
- * Returns true if the given dependency's licenses are all permissable for use in OSS
+ * Returns true if the given dependency's licenses are all permissible for use in OSS
  * @param {Object} dependency object containing the name and licenses of the given dependency
- * @returns {boolean} is permissable dependency
+ * @returns {boolean} is permissible dependency
  */
 function isPermissible(dependency) {
 	const licenses = dependency.licenses;


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Documentation change, corrects spelling typos in JSDoc comments within the `eslint-scope` package.

#### What changes did you make? (Give an overview)

Fixed four spelling typos in JSDoc comments. Comment-only changes; no runtime behavior is affected.

| File | Fix |
| --- | --- |
| `packages/eslint-scope/lib/pattern-visitor.js` | `Last elment` → `Last element` |
| `packages/eslint-scope/lib/index.js` | `Preform deep update` → `Perform deep update` |
| `packages/eslint-scope/tools/check-licenses.js` | `permissable` → `permissible` (×2) |

`check-licenses.js` names its function `isPermissible`, so the comment spelling was already inconsistent with the code.

#### Related Issues

#### Is there anything you'd like reviewers to focus on?
