### PR TITLE
chore: add allowScripts for yorkie

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "gitHooks": {
     "pre-commit": "lint-staged"
   },
+  "allowScripts": {
+    "yorkie": true
+  },
   "lint-staged": {
     "*.{js,cjs,ts,cts}": [
       "eslint --fix",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

npm 11.16.0+ warns when packages with install scripts are not listed in `allowScripts`.

Since this repository uses `yorkie` to set up Git hooks, running `npm install` produces the following warning:

```text
npm warn allow-scripts 1 package has install scripts not yet covered by allowScripts:
npm warn allow-scripts   yorkie@2.0.0 (install: node bin/install.js)
```

#### What changes did you make? (Give an overview)

Added the `allowScripts` field to `package.json` to allow yorkie's install script.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
